### PR TITLE
Adjust Dockerfile to build successfully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 # base node image
-FROM node:16-bullseye-slim as base
+FROM node:16-bullseye as base
 
 RUN apt-get update && apt-get install -y openssl
 
 RUN mkdir /app
 WORKDIR /app
 ENV NODE_ENV=production
-
-
-
 
 ADD . .
 


### PR DESCRIPTION
The Node slim image did not contain all needed packages to successfully build Actual. Changing to the standard image fixed the build process.

For reference, this is the error that popped up with the slim image:

```
 => ERROR [6/8] RUN yarn install --production                                                                                                                                                                            7.2s
------
 > [6/8] RUN yarn install --production:
#0 0.131 yarn install v1.22.18
#0 0.170 [1/4] Resolving packages...
#0 0.243 [2/4] Fetching packages...
#0 6.143 [3/4] Linking dependencies...
#0 6.144 warning " > eslint-config-react-app@3.0.6" has incorrect peer dependency "babel-eslint@9.x".
#0 6.144 warning " > eslint-config-react-app@3.0.6" has incorrect peer dependency "eslint-plugin-flowtype@2.x".
#0 6.492 [4/4] Building fresh packages...
#0 6.836 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
#0 6.836 error /app/node_modules/bcrypt: Command failed.
#0 6.836 Exit code: 1
#0 6.836 Command: node-pre-gyp install --fallback-to-build
#0 6.836 Arguments:
#0 6.836 Directory: /app/node_modules/bcrypt
#0 6.836 Output:
#0 6.836 node-pre-gyp info it worked if it ends with ok
#0 6.836 node-pre-gyp info using node-pre-gyp@1.0.8
#0 6.836 node-pre-gyp info using node@16.15.0 | linux | arm64
#0 6.836 node-pre-gyp info check checked for "/app/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node" (not found)
#0 6.836 node-pre-gyp http GET https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#0 6.836 node-pre-gyp ERR! install response status 404 Not Found on https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#0 6.836 node-pre-gyp WARN Pre-built binaries not installable for bcrypt@5.0.1 and node@16.15.0 (node-v93 ABI, glibc) (falling back to source compile with node-gyp)
#0 6.836 node-pre-gyp WARN Hit error response status 404 Not Found on https://github.com/kelektiv/node.bcrypt.js/releases/download/v5.0.1/bcrypt_lib-v5.0.1-napi-v3-linux-arm64-glibc.tar.gz
#0 6.836 gyp info it worked if it ends with ok
#0 6.836 gyp info using node-gyp@9.0.0
#0 6.836 gyp info using node@16.15.0 | linux | arm64
#0 6.836 gyp info ok
#0 6.836 gyp info it worked if it ends with ok
#0 6.836 gyp info using node-gyp@9.0.0
#0 6.836 gyp info using node@16.15.0 | linux | arm64
#0 6.836 gyp ERR! find Python
#0 6.836 gyp ERR! find Python Python is not set from command line or npm configuration
#0 6.836 gyp ERR! find Python Python is not set from environment variable PYTHON
....
```
Installing Python led to another issue because make did not exist, installing make led to weird error messages about missing _../node-addon-api/nothing.target.mk_ directories. I would leave it that way and call it a day.