### PR TITLE
Add hostname binding

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,8 +43,8 @@ async function run() {
   await accountApp.init();
   await syncApp.init();
 
-  console.log('Listening on ' + config.port + '...');
-  app.listen(config.port);
+  console.log('Listening on ' + config.hostname + ':' + config.port + '...');
+  app.listen(config.port, config.hostname);
 }
 
 run().catch(err => {

--- a/load-config.js
+++ b/load-config.js
@@ -9,6 +9,7 @@ try {
   config = {
     mode: 'development',
     port: 5006,
+    hostname: 'localhost',
     serverFiles: join(root, 'server-files'),
     userFiles: join(root, 'user-files')
   };

--- a/load-config.js
+++ b/load-config.js
@@ -9,7 +9,7 @@ try {
   config = {
     mode: 'development',
     port: 5006,
-    hostname: 'localhost',
+    hostname: '0.0.0.0',
     serverFiles: join(root, 'server-files'),
     userFiles: join(root, 'user-files')
   };


### PR DESCRIPTION
Added an option in the config file to bind to a given hostname (e.g. `localhost`). I intend to run the server behind a reverse proxy and I want to bind it localhost, so I thought others may also use this option :)

I've left the default to `0.0.0.0` in order to not break the current behavior.