### PR TITLE
Add Github Actions workflow to automatically build a Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      - name: Docker meta for Alpine image
+        id: alpine-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            actualbudget/actual-server
+            ghcr.io/actualbudget/actual-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,suffix=-alpine
+            type=semver,pattern={{version}},suffix=-alpine
+            type=semver,pattern={{major}}.{{minor}},suffix=-alpine
+            type=sha,suffix=-alpine
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -58,7 +73,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.DOCKERHUB_PROJECT }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build and push Alpine image
         uses: docker/build-push-action@v2
@@ -67,4 +82,4 @@ jobs:
           push: true
           file: Dockerfile.alpine
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.alpine-meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build Docker Image
 
+# Docker Images are only built when a new tag is created
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v*.*.*'
 
 jobs:
   build:
@@ -18,11 +19,38 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to Github
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # Push to both Docker Hub and Github Container Registry
+          images: |
+            actualbudget/actual-server
+            ghcr.io/actualbudget/actual-server
+          # Creates the following tags:
+          # - actual-server:latest
+          # - actual-server:1.3
+          # - actual-server:1.3.7
+          # - actual-server:sha-90dd603
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push standard image
         uses: docker/build-push-action@v2
@@ -39,4 +67,4 @@ jobs:
           push: true
           file: Dockerfile.alpine
           platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.DOCKERHUB_PROJECT }}:alpine
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Gitlab
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ secrets.DOCKERHUB_PROJECT }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push standard image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ secrets.DOCKERHUB_PROJECT }}:latest
+
+      - name: Build and push Alpine image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ secrets.DOCKERHUB_PROJECT }}:alpine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           # Push to both Docker Hub and Github Container Registry
           images: |
-            actualbudget/actual-server
+            jlongster/actual-server
             ghcr.io/actualbudget/actual-server
           # Creates the following tags:
           # - actual-server:latest
@@ -44,7 +44,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            actualbudget/actual-server
+            jlongster/actual-server
             ghcr.io/actualbudget/actual-server
           tags: |
             type=ref,event=branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to Gitlab
+      - name: Login to Github
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ Now, run `flyctl launch` from `actual-server`. You should have a running app now
 
 Whenever you want to update Actual, update the versions of `@actual-app/api` and `@actual-app/web` in `package.json` and run `flyctl  deploy`.
 
-**Note:** if you don't want to use fly, we still provide a `Dockerfile` to build the app so it should work anywhere that can compile a docker image.
+### Using a custom Docker setup
+
+Actual is also available as a Docker image ready to be run in your own custom environment.
+
+- Docker Hub: `jlongster/actual-server`
+- Github Registry: `ghcr.io/actualbudget/actual-server`
 
 ### Persisting server data
 


### PR DESCRIPTION
Add Github Actions workflow to automatically build a Docker image on the creation of tags to version the changes of the Actual server. The Docker image is pushed to both the Docker Hub and the Github Container Registry.

Caution: the following variables/secrets must be configured by the maintainer in the project settings:
- `DOCKERHUB_USERNAME` - User name on the Docker Hub
- `DOCKERHUB_TOKEN` - Token instead of a password, can be created in the Docker Hub [account settings](https://hub.docker.com/settings/security)