### PR TITLE
Adjust Dockerfile to use multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y openssl
 RUN mkdir /app
 WORKDIR /app
 ENV NODE_ENV=production
-ADD . .
+ADD yarn.lock package.json ./
 RUN yarn install --production
 
 FROM node:16-bullseye-slim as prod
@@ -12,4 +12,5 @@ FROM node:16-bullseye-slim as prod
 RUN apt-get update && apt-get install openssl && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=base /app /app
+ADD . .
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-# base node image
 FROM node:16-bullseye as base
 
 RUN apt-get update && apt-get install -y openssl
-
 RUN mkdir /app
 WORKDIR /app
 ENV NODE_ENV=production
-
 ADD . .
-
 RUN yarn install --production
-RUN mkdir ./server-files
-RUN mkdir ./user-files
 
+FROM node:16-bullseye-slim as prod
+
+RUN apt-get update && apt-get install openssl && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=base /app /app
 CMD ["yarn", "start"]


### PR DESCRIPTION
As described by [brtwrst](https://github.com/brtwrst) in my last pull request #1 , a multi-stage build reduces the final image size to the minimum.
I have not made changes to the first ADD command as I have no idea which files definitely need to be in the final image.