### PR TITLE
add: tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    // DOM for URL global in Node 16+
+    "lib": ["ES2021", "DOM"],
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "downlevelIteration": true,
+    "jsx": "preserve",
+    // Check JS files too
+    "allowJs": true,
+    "checkJs": true,
+    // Used for temp builds
+    "outDir": "build",
+    "moduleResolution": "Node",
+    "module": "ESNext"
+  },
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
This configures TypeScript and tells it to look at JS files as well, so that IDEs like VSCode can provide better edit-time checks.

This works especially well in VSCode with the ErrorLens extension which shows problems inline.

Problems with typings can be resolved by adding JSDoc comments (for which homer0 has an excellent Prettier plugin) or straight-up `*.d.ts` files, which will be used by the editor but otherwise don't impact the build at all.

This is a stepping stone towards TypeScript support, allowing a gradual conversion. Personally I use TS very sparingly, rely extensively on JSDoc and have great expectations for the [types proposal](https://github.com/sirisian/ecmascript-types).