### PR TITLE
Use Alpine Linux as base image for docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM node:16-bullseye as base
+FROM alpine as base
 
-RUN apt-get update && apt-get install -y openssl
+RUN apk add --no-cache nodejs yarn openssl tini
 RUN mkdir /app
 WORKDIR /app
 ENV NODE_ENV=production
 ADD yarn.lock package.json ./
 RUN yarn install --production
 
-FROM node:16-bullseye-slim as prod
+FROM alpine as prod
 
-RUN apt-get update && apt-get install openssl && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache nodejs yarn openssl tini
 WORKDIR /app
 COPY --from=base /app /app
 ADD . .
+
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["yarn", "start"]


### PR DESCRIPTION
This change reduces image size by 80% 

```
actual-alpine   latest            61b69b88643e   12 minutes ago   192MB
actual-debian   latest            43fa732027dc   17 minutes ago   1.09GB
```
Also use [tini](https://github.com/krallin/tini) as "container init" allowing a gracefully shutdown of container