### PR TITLE
Add GH Action workflow to publish Docker image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
+
+jobs:
+  build:
+    name: Build and publish Docker image
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    #if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set version from tag
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup tmate debug session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+    - name: Build container image
+      run: |
+        docker build \
+        --tag ghcr.io/pikapods/actual-server:${{ env.RELEASE_VERSION }} \
+        --tag ghcr.io/pikapods/actual-server:latest \
+        .
+    - name: Container registry login
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      
+    - name: Push image to GitHub
+      run: |
+        docker push ghcr.io/pikapods/actual-server:${{ env.RELEASE_VERSION }}
+        docker push ghcr.io/pikapods/actual-server:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,8 +28,8 @@ jobs:
     - name: Build container image
       run: |
         docker build \
-        --tag ghcr.io/pikapods/actual-server:${{ env.RELEASE_VERSION }} \
-        --tag ghcr.io/pikapods/actual-server:latest \
+        --tag ghcr.io/m3nu/actual-server:${{ env.RELEASE_VERSION }} \
+        --tag ghcr.io/m3nu/actual-server:latest \
         .
     - name: Container registry login
       run: |
@@ -37,5 +37,5 @@ jobs:
       
     - name: Push image to GitHub
       run: |
-        docker push ghcr.io/pikapods/actual-server:${{ env.RELEASE_VERSION }}
-        docker push ghcr.io/pikapods/actual-server:latest
+        docker push ghcr.io/m3nu/actual-server:${{ env.RELEASE_VERSION }}
+        docker push ghcr.io/m3nu/actual-server:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Build and publish Docker image
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    #if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
 
@@ -28,8 +28,8 @@ jobs:
     - name: Build container image
       run: |
         docker build \
-        --tag ghcr.io/m3nu/actual-server:${{ env.RELEASE_VERSION }} \
-        --tag ghcr.io/m3nu/actual-server:latest \
+        --tag ghcr.io/actualbudget/actual-server:${{ env.RELEASE_VERSION }} \
+        --tag ghcr.io/actualbudget/actual-server:latest \
         .
     - name: Container registry login
       run: |
@@ -37,5 +37,5 @@ jobs:
       
     - name: Push image to GitHub
       run: |
-        docker push ghcr.io/m3nu/actual-server:${{ env.RELEASE_VERSION }}
-        docker push ghcr.io/m3nu/actual-server:latest
+        docker push ghcr.io/actualbudget/actual-server:${{ env.RELEASE_VERSION }}
+        docker push ghcr.io/actualbudget/actual-server:latest


### PR DESCRIPTION
This adds a simple Github workflow to publish an official Docker image. I usually default to Github's registry to keep everything in one place. Of course the registry would be easy to adjust.

I usually publish a new image for tagged pushes, but this can be adjusted too.