### PR TITLE
Add one-click hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@ This is the main project to run [Actual](https://github.com/actualbudget/actual)
 
 Join the [discord](https://discord.gg/pRYNYr4W5A)!
 
-## One-Click Setup
-
-The button below deploys the Actual server on [PikaPods](https://www.pikapods.com). Just choose a name and geographic region. All files are accessible over SFTP, if you need to migrate or access them. The free welcome credit is enough to run Actual for around 3.5 months.
-
-[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=actual)
 
 ## Running
 
@@ -35,7 +30,8 @@ docker run -p 5006:5006 actual-server
 
 ## Deploying
 
-You should deploy your server so it's always running. We recommend [fly.io](https://fly.io) which makes it incredibly easy and provides a free plan.
+### Fly.io
+[fly.io](https://fly.io) allows running the application directly and provides a free tier. You should be comfortable with using the command line.
 
 [Create an account](https://fly.io/app/sign-in). Although you are required to enter payment details, everything we do here will work on the free tier and you won't be charged.
 
@@ -47,9 +43,7 @@ Now, run `flyctl launch` from `actual-server`. You should have a running app now
 
 Whenever you want to update Actual, update the versions of `@actual-app/api` and `@actual-app/web` in `package.json` and run `flyctl  deploy`.
 
-**Note:** if you don't want to use fly, we still provide a `Dockerfile` to build the app so it should work anywhere that can compile a docker image.
-
-### Persisting server data
+#### Persisting server data
 
 One problem with the above setup is every time you deploy, it will wipe away all the data on the server. You'll need to bootstrap the instance again and upload your files.
 
@@ -70,6 +64,18 @@ Now we need to tell Actual to use this volume. Add this in `fly.toml`:
 That's it! Actual will automatically check if the `/data` directory exists and use it automatically.
 
 _You can also configure the data dir with the `ACTUAL_USER_FILES` environment variable._
+
+
+### Docker
+We also provide a `Dockerfile` to deploy Actual to any platform that supports Docker. (official Docker image coming soon)
+
+
+### PikaPods
+Allows running Actual without using the command line via a pre-configured Docker image. Data is persisted and accessible via SFTP.
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=actual)
+
+
 
 ## Configuring the server URL
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run -p 5006:5006 actual-server
 ## Deploying
 
 ### Fly.io
-[fly.io](https://fly.io) allows running the application directly and provides a free tier. You should be comfortable with using the command line.
+[fly.io](https://fly.io) allows running the application directly and provides a free tier. You should be comfortable with using the command line to set it up though.
 
 [Create an account](https://fly.io/app/sign-in). Although you are required to enter payment details, everything we do here will work on the free tier and you won't be charged.
 
@@ -64,10 +64,6 @@ Now we need to tell Actual to use this volume. Add this in `fly.toml`:
 That's it! Actual will automatically check if the `/data` directory exists and use it automatically.
 
 _You can also configure the data dir with the `ACTUAL_USER_FILES` environment variable._
-
-
-### Docker
-We also provide a `Dockerfile` to deploy Actual to any platform that supports Docker. (official Docker image coming soon)
 
 
 ### PikaPods

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@ This is the main project to run [Actual](https://github.com/actualbudget/actual)
 
 Join the [discord](https://discord.gg/pRYNYr4W5A)!
 
-## Non-technical users
+## One-Click Setup
 
-We are looking into a feature for one-button click click deployment of Actual. This will reduce the friction for people not as comfortable with the command line.
+The button below deploys the Actual server on [PikaPods](https://www.pikapods.com). Just choose a name and geographic region. All files are accessible over SFTP, if you need to migrate or access them. The free welcome credit is enough to run Actual for around 3.5 months.
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=actual)
 
 ## Running
 


### PR DESCRIPTION
This adds the one-click hosting option mentioned in the README. Will use the official Docker image, once it's available.

About [PikaPods](https://www.pikapods.com): We just finished our beta program and focus on making privacy-conscious open source apps more accessible. Currently our app store offers around 50 apps and we run around 1500 pods. Currently there are 2 different regions, US and EU, with a third in Hong Kong joining soon. Users always have full access to their data over SFTP. We only sell hosting, so there are no ads, trackers or other limitations.

Button [preview](https://github.com/m3nu/actual-server/tree/add-single-click-hosting#one-click-setup)