### PR TITLE
Add Dockerfile.alpine for alpine buil; add tini to debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-FROM alpine as base
-
-RUN apk add --no-cache nodejs yarn openssl tini
-RUN mkdir /app
+FROM node:16-bullseye as base
+RUN apt-get update && apt-get install -y openssl
 WORKDIR /app
 ENV NODE_ENV=production
 ADD yarn.lock package.json ./
+RUN npm rebuild bcrypt --build-from-source
 RUN yarn install --production
 
-FROM alpine as prod
-
-RUN apk add --no-cache nodejs yarn openssl tini
+FROM node:16-bullseye-slim as prod
+RUN apt-get update && apt-get install openssl tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=base /app /app
 ADD . .
-
-ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["yarn", "start"]
+ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
+CMD ["node", "app.js"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,15 @@
+FROM alpine as base
+RUN apk add --no-cache nodejs yarn npm python3 openssl build-base
+WORKDIR /app
+ENV NODE_ENV=production
+ADD yarn.lock package.json ./
+RUN npm rebuild bcrypt --build-from-source
+RUN yarn install --production
+
+FROM alpine as prod
+RUN apk add --no-cache nodejs yarn openssl tini
+WORKDIR /app
+COPY --from=base /app /app
+ADD . .
+ENTRYPOINT ["/sbin/tini","-g",  "--"]
+CMD ["node", "app.js"]


### PR DESCRIPTION
This PR adds a separate `Dockerfile.alpine` to build an image based on Alpine Linux.
The resulting image will be just over 100M in size. 
The build and resulting image works on AMD64 (Tested on Ubuntu 20.04) and ARM64 (Tested on a RPI3 with Ubuntu 22.04)

During testing i switched between the `yarn start` and `node app.js` start commands and when using the latter, the container will exit with code 143 (which i think is the correct code) as opposed to exit code 1 when using `yarn start`. 
So i included the `node app.js` command for now.