### PR TITLE
Added github actions to automatically build docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Docker images CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: actualbudget
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/actualbudget/dashboard:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,4 +33,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/actualbudget/dashboard:latest
+            ghcr.io/actualbudget/actual-server:latest


### PR DESCRIPTION
This add github actions to automatically build docker images on push and pull request in master.
You need to then create a secret called GITHUB_TOKEN containing a Github Private access token with the right scope, as explained [here](https://github.com/docker/login-action#github-container-registry), in order to push images on the github container registry.
This will build for amd64 and arm64, other environment can be added.

PS : it may be really relevant for many people hosting by themselves when building docker images for a specific environment can be complicated.