### PR TITLE
Added easy directable url in actual budget

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const open = require('open');
 const express = require('express');
 const actuator = require('express-actuator');
 const bodyParser = require('body-parser');
@@ -46,8 +47,11 @@ async function run() {
   await accountApp.init();
   await syncApp.init();
 
-  console.log('Listening on ' + config.hostname + ':' + config.port + '...');
+  console.log('Listening on http://' + config.hostname + ':' + config.port);
   app.listen(config.port, config.hostname);
+
+  await open(`http://${config.hostname}:${config.port}`);
+
 }
 
 run().catch(err => {

--- a/app.js
+++ b/app.js
@@ -50,7 +50,9 @@ async function run() {
   console.log('Listening on http://' + config.hostname + ':' + config.port);
   app.listen(config.port, config.hostname);
 
-  await open(`http://${config.hostname}:${config.port}`);
+  try {
+    open(`http://${config.hostname}:${config.port}`);
+  } catch (err) { }
 
 }
 

--- a/load-config.js
+++ b/load-config.js
@@ -9,7 +9,7 @@ try {
   config = {
     mode: 'development',
     port: 5006,
-    hostname: '0.0.0.0',
+    hostname: 'localhost',
     serverFiles: join(root, 'server-files'),
     userFiles: join(root, 'user-files')
   };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express-actuator": "^1.8.1",
     "express-response-size": "^0.0.3",
     "node-fetch": "^2.2.0",
+    "open": "^8.4.0",
     "uuid": "^3.3.2"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -600,6 +600,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -1391,6 +1396,11 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -1431,6 +1441,13 @@ is-symbol@^1.0.2:
   integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   dependencies:
     has-symbols "^1.0.0"
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1811,6 +1828,15 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
Use the `open` package and modify the hostname from 0.0.0.0 to localhost to allow open default browser by default.

The projects are used to filter docker and anything else so there is no memory leak possibility if you run the server on a non-desktop environment. Reference: https://github.com/sindresorhus/open/blob/main/index.js.