### PR TITLE
Correct fly template port

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -5,7 +5,7 @@ kill_timeout = 5
 processes = []
 
 [env]
-  PORT = "8080"
+  PORT = "5006"
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
Deployments to fly.io were failing with error:
> Failed due to unhealthy allocations
Fixes #16