### PR TITLE
Refactor/ts conversion util dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 user-files
 server-files
+tsconfig.tsbuildinfo
+Dockerfile*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,9 @@ module.exports = {
   plugins: ['@typescript-eslint', 'prettier'],
   extends: ['eslint:recommended', "plugin:@typescript-eslint/recommended"],
   rules: {
-    "@typescript-eslint/no-var-requires": "off"
+    // TODO: currently set to match the existing code, though i recommend revisiting
+    'prefer-const': 'off',
+    '@typescript-eslint/no-var-requires': 'warn',
+    '@typescript-eslint/no-empty-function': 'warn'
   }
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 # syntax=docker/dockerfile:1
+FROM node:16-bullseye as build
+RUN apt-get update && apt-get install -y openssl
+WORKDIR /app
+COPY . .
+RUN yarn install && yarn build
+
 FROM node:16-bullseye as base
 RUN apt-get update && apt-get install -y openssl
 WORKDIR /app
 ENV NODE_ENV=production
+COPY --from=build /app/build ./
 COPY yarn.lock package.json ./
+COPY migrations ./migrations
+COPY sql ./sql
 RUN npm rebuild bcrypt --build-from-source && \
     yarn install --production
 
@@ -11,6 +20,5 @@ FROM node:16-bullseye-slim as prod
 RUN apt-get update && apt-get -y install openssl tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=base /app /app
-COPY . .
 ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
 CMD ["node", "app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
+# syntax=docker/dockerfile:1
 FROM node:16-bullseye as base
 RUN apt-get update && apt-get install -y openssl
 WORKDIR /app
 ENV NODE_ENV=production
-ADD yarn.lock package.json ./
-RUN npm rebuild bcrypt --build-from-source
-RUN yarn install --production
+COPY yarn.lock package.json ./
+RUN npm rebuild bcrypt --build-from-source && \
+    yarn install --production
 
 FROM node:16-bullseye-slim as prod
-RUN apt-get update && apt-get install openssl tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install openssl tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=base /app /app
-ADD . .
+COPY . .
 ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
 CMD ["node", "app.js"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,12 +1,13 @@
-FROM alpine as base
+# syntax=docker/dockerfile:1
+FROM alpine:3 as base
 RUN apk add --no-cache nodejs yarn npm python3 openssl build-base
 WORKDIR /app
 ENV NODE_ENV=production
-ADD yarn.lock package.json ./
-RUN npm rebuild bcrypt --build-from-source
-RUN yarn install --production
+COPY yarn.lock package.json ./
+RUN npm rebuild bcrypt --build-from-source && \
+    yarn install --production
 
-FROM alpine as prod
+FROM alpine:3 as prod
 RUN apk add --no-cache nodejs yarn openssl tini
 WORKDIR /app
 COPY --from=base /app /app

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,16 +1,24 @@
 # syntax=docker/dockerfile:1
+FROM alpine:3 as build
+RUN apk add --no-cache nodejs yarn npm python3 openssl build-base
+WORKDIR /app
+COPY . .
+RUN yarn install && yarn build
+
 FROM alpine:3 as base
 RUN apk add --no-cache nodejs yarn npm python3 openssl build-base
 WORKDIR /app
 ENV NODE_ENV=production
+COPY --from=build /app/build ./
 COPY yarn.lock package.json ./
+COPY migrations ./migrations
+COPY sql ./sql
 RUN npm rebuild bcrypt --build-from-source && \
     yarn install --production
 
 FROM alpine:3 as prod
-RUN apk add --no-cache nodejs yarn openssl tini
+RUN apk add --no-cache nodejs openssl tini
 WORKDIR /app
 COPY --from=base /app /app
-ADD . .
 ENTRYPOINT ["/sbin/tini","-g",  "--"]
 CMD ["node", "app.js"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's very easy to get started. Clone this repo, install deps, and start it:
 git clone https://github.com/actualbudget/actual-server.git
 cd actual-server
 yarn install
-yarn start
+yarn dev
 ```
 
 Go to https://localhost:5006 in your browser and you'll see Actual.

--- a/app-account.js
+++ b/app-account.js
@@ -1,7 +1,7 @@
 let express = require('express');
 let bcrypt = require('bcrypt');
 let uuid = require('uuid');
-let errorMiddleware = require('./util/error-middleware');
+let errorMiddleware = require('./util/error-middleware').default;
 let { validateUser } = require('./util/validate-user');
 let { getAccountDb } = require('./account-db');
 

--- a/app-sync.js
+++ b/app-sync.js
@@ -4,7 +4,7 @@ let express = require('express');
 let uuid = require('uuid');
 let AdmZip = require('adm-zip');
 let { validateUser } = require('./util/validate-user');
-let errorMiddleware = require('./util/error-middleware');
+let errorMiddleware = require('./util/error-middleware').default;
 let config = require('./load-config');
 let { getAccountDb } = require('./account-db');
 

--- a/app-sync.js
+++ b/app-sync.js
@@ -228,12 +228,14 @@ app.post('/upload-user-file', async (req, res) => {
   }
 
   let accountDb = getAccountDb();
+  // @ts-expect-error TS2345: we're apparently confident this is not an array
   let name = decodeURIComponent(req.headers['x-actual-name']);
   let fileId = req.headers['x-actual-file-id'];
   let groupId = req.headers['x-actual-group-id'] || null;
   let encryptMeta = req.headers['x-actual-encrypt-meta'] || null;
   let syncFormatVersion = req.headers['x-actual-format'] || null;
 
+  // @ts-expect-error TS2345: we're apparently confident this is not an array
   let keyId = encryptMeta ? JSON.parse(encryptMeta).keyId : null;
 
   if (!fileId) {
@@ -282,6 +284,7 @@ app.post('/upload-user-file', async (req, res) => {
   let zip = new AdmZip(req.body);
 
   try {
+    // @ts-expect-error TS2345: we're apparently confident this is not an array
     zip.extractAllTo(join(config.userFiles, fileId), true);
   } catch (err) {
     console.log('Error writing file', err);
@@ -337,6 +340,7 @@ app.get('/download-user-file', async (req, res) => {
 
   let zip = new AdmZip();
   try {
+    // @ts-expect-error TS2345: we're apparently confident this is not an array
     zip.addLocalFolder(join(config.userFiles, fileId), '/');
   } catch (e) {
     res.status(500).send('Error reading files');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node app",
+    "dev": "ts-node app",
     "lint": "eslint .",
     "build": "tsc",
     "types": "tsc --noEmit --incremental",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.6.2",
     "@types/better-sqlite3": "^7.5.0",
+    "@types/express": "^4.17.13",
     "@types/node": "^17.0.31",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "ts-node app",
     "lint": "eslint .",
     "build": "tsc",
+    "clean": "rm -rf build",
     "types": "tsc --noEmit --incremental",
     "verify": "yarn -s lint && yarn types"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "actual syncing server",
   "main": "index.js",
   "scripts": {
-    "start": "node app",
+    "start": "node build/app",
     "dev": "ts-node app",
     "lint": "eslint .",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prettier": "^2.6.2",
     "@types/better-sqlite3": "^7.5.0",
     "@types/node": "^17.0.31",
+    "ts-node": "^10.7.0",
     "typescript": "^4.6.4"
   }
 }

--- a/util/async.ts
+++ b/util/async.ts
@@ -1,4 +1,4 @@
-function sequential(fn) {
+export function sequential<T>(fn) {
   let sequenceState = {
     running: null,
     queue: []
@@ -17,18 +17,18 @@ function sequential(fn) {
     sequenceState.running = fn(...args);
 
     sequenceState.running.then(
-      val => {
+      (val) => {
         pump();
         resolve(val);
       },
-      err => {
+      (err) => {
         pump();
         reject(err);
       }
     );
   }
 
-  return (...args) => {
+  return (...args): Promise<T> => {
     if (!sequenceState.running) {
       return new Promise((resolve, reject) => {
         return run(args, resolve, reject);
@@ -41,4 +41,4 @@ function sequential(fn) {
   };
 }
 
-module.exports = { sequential };
+export default { sequential };

--- a/util/error-middleware.js
+++ b/util/error-middleware.js
@@ -1,6 +1,0 @@
-async function middleware(err, req, res) {
-  console.log('ERROR', err);
-  res.status(500).send({ status: 'error', reason: 'internal-error' });
-}
-
-module.exports = middleware;

--- a/util/error-middleware.ts
+++ b/util/error-middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+
+async function middleware(
+  err,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  console.log('ERROR', err);
+  res.status(500).send({ status: 'error', reason: 'internal-error' });
+}
+
+export default middleware;

--- a/util/validate-user.ts
+++ b/util/validate-user.ts
@@ -1,6 +1,7 @@
-let { getAccountDb } = require('../account-db');
+import { Request, Response } from 'express';
+import { getAccountDb } from '../account-db';
 
-function validateUser(req, res) {
+export function validateUser(req: Request, res: Response) {
   let { token } = req.body || {};
 
   if (!token) {
@@ -23,4 +24,4 @@ function validateUser(req, res) {
   return rows[0];
 }
 
-module.exports = { validateUser };
+export default { validateUser };

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,15 +120,72 @@
   dependencies:
     "@types/node" "*"
 
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/node@*", "@types/node@^17.0.31":
   version "17.0.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
   integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.23.0":
   version "5.23.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,18 @@
   resolved "https://registry.yarnpkg.com/@actual-app/web/-/web-4.0.2.tgz#9311274bbe3464106d4b1d994947128c672d11d0"
   integrity sha512-UGsZ1PBZuFM8temch6J8t6Z18JzFqDvrweWg77Vje1nyBFqwTKzsWrABbinxJF9fI+qiYH5T/eTftj7/JB0f3A==
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@eslint/eslintrc@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.2.3.tgz#fcaa2bcef39e13d6e9e7f6271f4cc7cae1174886"
@@ -80,6 +92,26 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
 "@types/better-sqlite3@^7.5.0":
   version "7.5.0"
@@ -203,7 +235,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.7.1:
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1, acorn@^8.7.1:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
@@ -277,6 +314,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -518,6 +560,11 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -600,6 +647,11 @@ detect-libc@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1325,6 +1377,11 @@ make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -2107,6 +2164,25 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+ts-node@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -2182,6 +2258,11 @@ uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -2239,3 +2320,8 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
#### Blockers
Based on #39. Will be rebased and reviewable if/when that pr makes progress. Until then it looks far larger than it is, because those commits are also present.
May also need to be updated after the prettier pr #43.

#### Details to note
- `handle-error.js` is only imported by `app-plaid.js`, which is currently unused. As such it hasn't been touched.
- `app-account.js` and `app-sync.js` changes will be gone as soon as those files are converted to ts. eg
`let errorMiddleware = require('./util/error-middleware').default;`
becomes
`import errorMiddleware from './util/error-middleware';`

- The lint rule changes are currently there to reflect the existing code (ie to minimize changes in the pr). Personally I'd prefer things like `prefer-const` enabled and fixed. If we can agree on that, we can make those changes (a bunch of `let` swapped for `const`) here or in a follow up.