### PR TITLE
fix: error handling middleware signature

### DIFF
--- a/util/error-middleware.js
+++ b/util/error-middleware.js
@@ -1,4 +1,4 @@
-async function middleware(err, req, res) {
+async function middleware(err, req, res, next) {
   console.log('ERROR', err);
   res.status(500).send({ status: 'error', reason: 'internal-error' });
 }


### PR DESCRIPTION
Error handling middleware functions must have four arguments to
identify it as such.

Fixes #40

See https://expressjs.com/en/api.html

>Error-handling middleware always takes four arguments. You must provide four arguments to identify it as an error-handling middleware function. Even if you don’t need to use the next object, you must specify it to maintain the signature. Otherwise, the next object will be interpreted as regular middleware and will fail to handle errors.