### PR TITLE
Fix Cross-Origin issues to enable `SharedArrayBuffer`

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,16 @@ app.get('/mode', (req, res) => {
 app.use(actuator()); // Provides /health, /metrics, /info
 
 // The web frontend
-app.use(express.static(__dirname + '/node_modules/@actual-app/web/build'));
+app.use((req, res, next) => {
+  res.set('Cross-Origin-Opener-Policy', 'same-origin');
+  res.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  next();
+});
+app.use(
+  express.static(__dirname + '/node_modules/@actual-app/web/build', {
+    index: false
+  })
+);
 app.get('/*', (req, res) => {
   res.sendFile(__dirname + '/node_modules/@actual-app/web/build/index.html');
 });


### PR DESCRIPTION
This is the fix which enables an entirely different storage layer for Actual, and fixes all syncing/file issues with it. 

This took a while because I needed to get https://github.com/actualbudget/actual/pull/71 in first. I haven't released that change yet, but will do that this weekend. Once it's merged, I'll merge this PR.

You should export your data first before updating to this PR. The new storage layer will likely not be able to read your old data so it's really import that you'll be able to import your old data.