### PR TITLE
Chore/eslint yaml files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,8 +7,15 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'prettier'],
-  extends: ['eslint:recommended', "plugin:@typescript-eslint/recommended"],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   rules: {
-    "@typescript-eslint/no-var-requires": "off"
-  }
+    'prettier/prettier': 'error',
+    '@typescript-eslint/no-var-requires': 'off'
+  },
+  overrides: [
+    {
+      files: ['*.yml', '*.yaml'],
+      parser: 'yaml-eslint-parser'
+    }
+  ]
 };

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build Docker Image
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    branches: '*'
+    branches: "*"
 
 jobs:
   lint:
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: yarn --immutable

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,12 @@
 {
     "singleQuote": true,
-    "trailingComma": "none"
+    "trailingComma": "none",
+  "overrides": [
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-    "singleQuote": true,
-    "trailingComma": "none",
+  "singleQuote": true,
+  "trailingComma": "none",
   "overrides": [
     {
       "files": ["*.yml", "*.yaml"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node app",
-    "lint": "eslint .",
+    "lint": "eslint . .github",
     "build": "tsc",
     "types": "tsc --noEmit --incremental",
     "verify": "yarn -s lint && yarn types"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prettier": "^2.6.2",
     "@types/better-sqlite3": "^7.5.0",
     "@types/node": "^17.0.31",
-    "typescript": "^4.6.4"
+    "typescript": "^4.6.4",
+    "yaml-eslint-parser": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1312,6 +1312,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -2239,3 +2244,17 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml-eslint-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/yaml-eslint-parser/-/yaml-eslint-parser-1.0.1.tgz#f1f867dc2e4c5101a3b60533b1cd181bed8cca3e"
+  integrity sha512-acQYWneSXwnJgPQbTyJvDxWx9zlJ/rq267p/zzQMSCE7ljJxQ8elefsQase1gEIJMo+pIqmLRczoo7fPt6VbKQ==
+  dependencies:
+    eslint-visitor-keys "^3.0.0"
+    lodash "^4.17.21"
+    yaml "^2.0.0"
+
+yaml@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
+  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==


### PR DESCRIPTION
This PR extends linting/styling to cover YAML files, including those in gh-action workflows. It uses Prettier with double quotes specified for YAML. 

The style updates in #43 have not been duplicated here. There's no dependency on that PR, but the changes are relevant (ie not having those changes in causes the lint CI failure) .

If at some point there is a desire to apply more rules to YAML files, [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml) offers a wider selection.