### PR TITLE
OpenAPI spec

### DIFF
--- a/oapi.yml
+++ b/oapi.yml
@@ -11,6 +11,8 @@ tags:
     description: health check endpoints
   - name: account
     description: account
+  - name: sync
+    description: sync
 paths:
   "/info":
     get:
@@ -251,6 +253,44 @@ paths:
               examples:
                 success:
                   value: { status: "ok", data: { validated: true } }
+        "401":
+          $ref: "#/components/responses/unauth-user"
+        "500":
+          $ref: "#/components/responses/error-internal"
+  "/sync/sync":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        description: Protobuf serialized sync request
+        required: true
+        content:
+          application/octet-stream: {}
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/actual-sync: {}
+        "400":
+          description: Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                file-not-found:
+                  value: file-not-found
+                file-old-version:
+                  value: file-old-version
+                file-needs-upload:
+                  value: file-needs-upload
+                file-has-reset:
+                  value: file-has-reset
+                file-has-new-key:
+                  value: file-has-new-key
         "401":
           $ref: "#/components/responses/unauth-user"
         "500":

--- a/oapi.yml
+++ b/oapi.yml
@@ -1,0 +1,128 @@
+openapi: 3.0.0
+info:
+  title: Actual Server
+  version: 1.0.2
+  description: "Actual Budget sync server."
+tags:
+  - name: health-check
+    description: health check endpoints
+paths:
+  "/info":
+    get:
+      summary: Displays application information.
+      tags:
+        - health-check
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Info"
+              examples:
+                success:
+                  $ref: "#/components/examples/info"
+  "/health":
+    get:
+      summary: Shows application health information.
+      tags:
+        - health-check
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+              examples:
+                success:
+                  $ref: "#/components/examples/health"
+  "/metrics":
+    get:
+      summary: Shows metrics information for the current application.
+      tags:
+        - health-check
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Metrics"
+              examples:
+                success:
+                  $ref: "#/components/examples/metrics"
+  "/mode":
+    get:
+      summary: Shows the mode set in the current server configuration.
+      tags:
+        - health-check
+      responses:
+        "200":
+          description: Ok
+          content:
+            text/html:
+              schema:
+                type: string
+components:
+  schemas:
+    Info:
+      type: object
+      properties:
+        build:
+          type: object
+          properties:
+            description:
+              type: string
+            name:
+              type: string
+            version:
+              type: string
+    Health:
+      type: object
+      properties:
+        status:
+          type: string
+    Metrics:
+      type: object
+      properties:
+        mem:
+          type: object
+          properties:
+            heapTotal:
+              type: number
+            heapUsed:
+              type: number
+            rss:
+              type: number
+            external:
+              type: number
+            arrayBuffers:
+              type: number
+        uptime:
+          type: number
+  examples:
+    info:
+      value:
+        {
+          "build":
+            {
+              "description": "This is my new app",
+              "name": "MyApp",
+              "version": "1.0.0"
+            },
+          "git":
+            {
+              "branch": "master",
+              "commit": { "id": "329a314", "time": "2016-11-18 08:16:39-0500" }
+            }
+        }
+    health:
+      value: { "status": "UP" }
+    metrics:
+      value:
+        {
+          "mem":
+            { "heapTotal": 14659584, "heapUsed": 10615072, "rss": 30093312 },
+          "uptime": 19.797
+        }

--- a/oapi.yml
+++ b/oapi.yml
@@ -487,6 +487,48 @@ paths:
                   value: file-has-new-key
         "500":
           $ref: "#/components/responses/error-internal"
+  "/sync/download-user-file":
+    get:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+        - name: x-actual-file-id
+          in: header
+          required: true
+          description: File ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/octet-stream: {}
+        "400":
+          description: Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                file-not-found:
+                  value: User or file not found
+        "500":
+          description: Internal Server Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                read-err:
+                  value: Error reading files
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrInternal"
+              examples:
+                err:
+                  $ref: "#/components/examples/err-internal"
 components:
   schemas:
     Info:
@@ -536,6 +578,13 @@ components:
       properties:
         status:
           type: string
+    ErrInternal:
+      type: object
+      properties:
+        status:
+          type: string
+        reason:
+          type: string
   examples:
     info:
       value:
@@ -563,6 +612,8 @@ components:
         }
     token:
       value: { status: "ok", data: { token: "token" } }
+    err-internal:
+      value: { status: "error", reason: "internal-error" }
   parameters:
     token-header:
       name: x-actual-token
@@ -598,15 +649,10 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              status:
-                type: string
-              reason:
-                type: string
+            $ref: "#/components/schemas/ErrInternal"
           examples:
             err:
-              value: { status: "error", reason: "internal-error" }
+              $ref: "#/components/examples/err-internal"
     ok-nodata:
       description: Ok
       content:

--- a/oapi.yml
+++ b/oapi.yml
@@ -89,6 +89,8 @@ paths:
               examples:
                 success:
                   value: { status: "ok", data: { bootstrapped: true } }
+        "500":
+          $ref: "#/components/responses/error-internal"
   "/account/bootstrap":
     post:
       summary: bootstrap the server
@@ -137,6 +139,8 @@ paths:
                   value: { status: "error", reason: "already-bootstrapped" }
                 invalid-password:
                   value: { status: "error", reason: "invalid-password" }
+        "500":
+          $ref: "#/components/responses/error-internal"
   "/account/login":
     post:
       summary: Logs in to the server
@@ -169,6 +173,8 @@ paths:
                   $ref: "#/components/examples/token"
                 failure:
                   value: { status: "ok", data: { token: null } }
+        "500":
+          $ref: "#/components/responses/error-internal"
   "/account/change-password":
     post:
       summary: Update a user password
@@ -205,6 +211,8 @@ paths:
                   value: { status: "ok", data: {} }
         "401":
           $ref: "#/components/responses/unauth-user"
+        "500":
+          $ref: "#/components/responses/error-internal"
   "/account/validate":
     get:
       summary: Validate account access
@@ -242,6 +250,8 @@ paths:
                   value: { status: "ok", data: { validated: true } }
         "401":
           $ref: "#/components/responses/unauth-user"
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:
@@ -343,3 +353,17 @@ components:
                   reason: "unauthorized",
                   details: "token-not-found"
                 }
+    error-internal:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+              reason:
+                type: string
+          examples:
+            err:
+              value: { status: "error", reason: "internal-error" }

--- a/oapi.yml
+++ b/oapi.yml
@@ -295,6 +295,68 @@ paths:
           $ref: "#/components/responses/unauth-user"
         "500":
           $ref: "#/components/responses/error-internal"
+  "/sync/user-get-key":
+    # TODO why exactly is this a POST and not a GET?
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileId:
+                  type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        nullable: true
+                      salt:
+                        type: string
+                        nullable: true
+                      test:
+                        type: string
+                        nullable: true
+              examples:
+                success:
+                  value:
+                    {
+                      status: "ok",
+                      data:
+                        {
+                          id: encrypt_keyid,
+                          salt: encrypt_salt,
+                          test: encrypt_test
+                        }
+                    }
+        "400":
+          description: Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                file-not-found:
+                  value: file-not-found
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -6,6 +6,8 @@ info:
 tags:
   - name: health-check
     description: health check endpoints
+  - name: account
+    description: account
 paths:
   "/info":
     get:
@@ -64,6 +66,29 @@ paths:
             text/html:
               schema:
                 type: string
+  "/account/needs-bootstrap":
+    get:
+      summary: returns bootstrap status
+      tags:
+        - account
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      bootstrapped:
+                        type: boolean
+              examples:
+                success:
+                  value: { status: "ok", data: { bootstrapped: true } }
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -3,6 +3,9 @@ info:
   title: Actual Server
   version: 1.0.2
   description: "Actual Budget sync server."
+servers:
+  - url: http://localhost:5006
+    description: Local development
 tags:
   - name: health-check
     description: health check endpoints

--- a/oapi.yml
+++ b/oapi.yml
@@ -529,6 +529,40 @@ paths:
               examples:
                 err:
                   $ref: "#/components/examples/err-internal"
+  "/sync/list-user-files":
+    get:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    $ref: "#/components/schemas/FileList"
+        "500":
+          description: Internal Server Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                read-err:
+                  value: Error reading files
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrInternal"
+              examples:
+                err:
+                  $ref: "#/components/examples/err-internal"
 components:
   schemas:
     Info:
@@ -585,6 +619,23 @@ components:
           type: string
         reason:
           type: string
+    File:
+      type: object
+      properties:
+        deleted:
+          type: boolean
+        fileId:
+          type: string
+        groupId:
+          type: string
+        name:
+          type: string
+        encryptKeyId:
+          type: string
+    FileList:
+      type: array
+      items:
+        $ref: "#/components/schemas/File"
   examples:
     info:
       value:

--- a/oapi.yml
+++ b/oapi.yml
@@ -175,12 +175,7 @@ paths:
       tags:
         - account
       parameters:
-        - in: header
-          name: x-actual-token
-          description: Session token, if not provided in the request body.
-          required: false
-          schema:
-            type: string
+        - $ref: "#/components/parameters/token-header"
       requestBody:
         required: true
         content:
@@ -209,7 +204,27 @@ paths:
                 success:
                   value: { status: "ok", data: {} }
         "401":
-          description: Unauthorized
+          $ref: "#/components/responses/unauth-user"
+  "/account/validate":
+    get:
+      summary: Validate account access
+      tags:
+        - account
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        # required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                  nullable: true
+      responses:
+        "200":
+          description: Ok
           content:
             application/json:
               schema:
@@ -217,18 +232,16 @@ paths:
                 properties:
                   status:
                     type: string
-                  reason:
-                    type: string
-                  details:
-                    type: string
+                  data:
+                    type: object
+                    properties:
+                      validated:
+                        type: boolean
               examples:
-                unauth:
-                  value:
-                    {
-                      status: "error",
-                      reason: "unauthorized",
-                      details: "token-not-found"
-                    }
+                success:
+                  value: { status: "ok", data: { validated: true } }
+        "401":
+          $ref: "#/components/responses/unauth-user"
 components:
   schemas:
     Info:
@@ -300,3 +313,33 @@ components:
         }
     token:
       value: { status: "ok", data: { token: "token" } }
+  parameters:
+    token-header:
+      name: x-actual-token
+      in: header
+      required: false
+      description: Session token, if not provided in the request body.
+      schema:
+        type: string
+  responses:
+    unauth-user:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+              reason:
+                type: string
+              details:
+                type: string
+          examples:
+            unauth:
+              value:
+                {
+                  status: "error",
+                  reason: "unauthorized",
+                  details: "token-not-found"
+                }

--- a/oapi.yml
+++ b/oapi.yml
@@ -414,6 +414,79 @@ paths:
                   value: User or file not found
         "500":
           $ref: "#/components/responses/error-internal"
+  "/sync/upload-user-file":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+        - name: x-actual-file-id
+          in: header
+          required: true
+          description: File ID
+          schema:
+            type: string
+        - name: x-actual-group-id
+          in: header
+          required: false
+          description: Group ID
+          schema:
+            type: string
+        - name: x-actual-encrypt-meta
+          in: header
+          required: false
+          description: Encryption metadata
+          schema:
+            # TODO: actually JSON with shape...?
+            type: string
+        - name: x-actual-format
+          in: header
+          required: false
+          description: Sync format version
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/octet-stream: {}
+      responses:
+        "200":
+          description: Ok or write error
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [status, groupId]
+                    properties:
+                      status:
+                        type: string
+                      groupId:
+                        type: string
+                  - type: object
+                    additionalProperties: false
+                    properties:
+                      status:
+                        type: string
+              examples:
+                success:
+                  value: { status: "ok", groupId: "groupId" }
+                write-err:
+                  value: { status: "error" }
+        "400":
+          description: Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                file-has-reset:
+                  value: file-has-reset
+                file-has-new-key:
+                  value: file-has-new-key
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -169,6 +169,66 @@ paths:
                   $ref: "#/components/examples/token"
                 failure:
                   value: { status: "ok", data: { token: null } }
+  "/account/change-password":
+    post:
+      summary: Update a user password
+      tags:
+        - account
+      parameters:
+        - in: header
+          name: x-actual-token
+          description: Session token, if not provided in the request body.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "#/components/schemas/Login"
+                - type: object
+                  properties:
+                    token:
+                      type: string
+                      nullable: true
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+              examples:
+                success:
+                  value: { status: "ok", data: {} }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  reason:
+                    type: string
+                  details:
+                    type: string
+              examples:
+                unauth:
+                  value:
+                    {
+                      status: "error",
+                      reason: "unauthorized",
+                      details: "token-not-found"
+                    }
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -381,17 +381,37 @@ paths:
                   type: string
       responses:
         "200":
-          description: Ok
+          $ref: "#/components/responses/ok-nodata"
+        "500":
+          $ref: "#/components/responses/error-internal"
+  "/sync/reset-user-file":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileId:
+                  type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/ok-nodata"
+        "400":
+          description: Error
           content:
-            application/json:
+            text/html:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
+                type: string
               examples:
-                success:
-                  value: { status: "ok" }
+                file-not-found:
+                  value: User or file not found
         "500":
           $ref: "#/components/responses/error-internal"
 components:
@@ -438,6 +458,11 @@ components:
           type: string
       required:
         - password
+    Ok:
+      type: object
+      properties:
+        status:
+          type: string
   examples:
     info:
       value:
@@ -509,3 +534,12 @@ components:
           examples:
             err:
               value: { status: "error", reason: "internal-error" }
+    ok-nodata:
+      description: Ok
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Ok"
+          examples:
+            success:
+              value: { status: "ok" }

--- a/oapi.yml
+++ b/oapi.yml
@@ -649,6 +649,27 @@ paths:
                   value: { status: "error" }
         "500":
           $ref: "#/components/responses/error-internal"
+  "/sync/delete-user-file":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileId:
+                  type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/ok-nodata"
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -357,6 +357,43 @@ paths:
                   value: file-not-found
         "500":
           $ref: "#/components/responses/error-internal"
+  "/sync/user-create-key":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileId:
+                  type: string
+                keyId:
+                  type: string
+                keySalt:
+                  type: string
+                testContent:
+                  type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+              examples:
+                success:
+                  value: { status: "ok" }
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -599,6 +599,56 @@ paths:
               examples:
                 err:
                   $ref: "#/components/examples/err-internal"
+  "/sync/get-user-file-info":
+    get:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+        - name: x-actual-file-id
+          in: header
+          required: true
+          description: File ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [status, data]
+                    properties:
+                      status:
+                        type: string
+                      data:
+                        $ref: "#/components/schemas/File"
+                  - type: object
+                    additionalProperties: false
+                    properties:
+                      status:
+                        type: string
+              examples:
+                success:
+                  value:
+                    {
+                      status: "ok",
+                      data:
+                        {
+                          deleted: false,
+                          fileId: "row.id",
+                          groupId: "row.group_id",
+                          name: "row.name",
+                          encryptMeta: "row.encrypt_meta"
+                        }
+                    }
+                no-rows:
+                  value: { status: "error" }
+        "500":
+          $ref: "#/components/responses/error-internal"
 components:
   schemas:
     Info:

--- a/oapi.yml
+++ b/oapi.yml
@@ -529,6 +529,42 @@ paths:
               examples:
                 err:
                   $ref: "#/components/examples/err-internal"
+  "/sync/update-user-filename":
+    post:
+      # summary: TODO
+      tags:
+        - sync
+      parameters:
+        - $ref: "#/components/parameters/token-header"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fileId:
+                  type: string
+                name:
+                  type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/ok-nodata"
+        "500":
+          description: Internal Server Error
+          content:
+            text/html:
+              schema:
+                type: string
+              examples:
+                read-err:
+                  value: User or file not found
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrInternal"
+              examples:
+                err:
+                  $ref: "#/components/examples/err-internal"
   "/sync/list-user-files":
     get:
       # summary: TODO

--- a/oapi.yml
+++ b/oapi.yml
@@ -120,7 +120,7 @@ paths:
                         type: string
               examples:
                 success:
-                  value: { status: "ok", data: { token: "token" } }
+                  $ref: "#/components/examples/token"
         "400":
           description: error
           content:
@@ -137,6 +137,38 @@ paths:
                   value: { status: "error", reason: "already-bootstrapped" }
                 invalid-password:
                   value: { status: "error", reason: "invalid-password" }
+  "/account/login":
+    post:
+      summary: Logs in to the server
+      tags:
+        - account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Login"
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                        nullable: true
+              examples:
+                success:
+                  $ref: "#/components/examples/token"
+                failure:
+                  value: { status: "ok", data: { token: null } }
 components:
   schemas:
     Info:
@@ -174,6 +206,13 @@ components:
               type: number
         uptime:
           type: number
+    Login:
+      type: object
+      properties:
+        password:
+          type: string
+      required:
+        - password
   examples:
     info:
       value:
@@ -199,3 +238,5 @@ components:
             { "heapTotal": 14659584, "heapUsed": 10615072, "rss": 30093312 },
           "uptime": 19.797
         }
+    token:
+      value: { status: "ok", data: { token: "token" } }

--- a/oapi.yml
+++ b/oapi.yml
@@ -89,6 +89,54 @@ paths:
               examples:
                 success:
                   value: { status: "ok", data: { bootstrapped: true } }
+  "/account/bootstrap":
+    post:
+      summary: bootstrap the server
+      tags:
+        - account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+              examples:
+                success:
+                  value: { status: "ok", data: { token: "token" } }
+        "400":
+          description: error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  reason:
+                    type: string
+              examples:
+                already-bootstrapped:
+                  value: { status: "error", reason: "already-bootstrapped" }
+                invalid-password:
+                  value: { status: "error", reason: "invalid-password" }
 components:
   schemas:
     Info:


### PR DESCRIPTION
As there are evidently new implementations of actual-server being developed, it would be useful to have a language agnostic spec for the server. [OpenAPI](https://www.openapis.org/about) seems like a viable candidate for this purpose.

Having a single standard allows any potential implementation or user thereof to test that the implementation is a *complete* actual-server. It avoids individual developers deciding what is and is not "critical" to implement, a process which can lead to servers that do not work with the official clients. OpenAPI is also supported by a variety of tools, from testing tools ([Insomnia](https://insomnia.rest/), [Postman](https://www.postman.com/), etc) to code generators ([oapi-codegen (golang)](https://github.com/deepmap/oapi-codegen), [oapi-generator (many)](https://openapi-generator.tech/), etc).

I'm not certain it's complete, but it should be very close. There are definitely error conditions (particularly those that would return `500`) i've included in the spec but haven't directly checked.

A few notes (some from memory as I neglected to write them down as I worked):
- protobuf responses are currently listed as `application/octet-stream`, except for the one case where the implementation clearly specifies otherwise https://github.com/actualbudget/actual-server/blob/f83fe76280539a3e838e0c7b7d0e2a8a64924978/app-sync.js#L141
- `sync/user-get-key` doesn't look like it should be a POST, as it just reads data and returns it, but it's in the spec the way it's currently imlemented 
- a number of json responses (eg `/sync/list-user-files`) are being sent with `Content-Type text/html; charset=utf-8`
  This is the default for express' `res.send()` method when the content is a string. We could manually set the header, or remove    the `JSON.stringify` calls (as express' default behavior when passed an object is to set the content-type to `application/json`).    It clearly parses as is, so we could also do nothing. They're currently listed as JSON in the spec, despite this. https://github.com/actualbudget/actual-server/blob/f83fe76280539a3e838e0c7b7d0e2a8a64924978/app-sync.js#L376-L387
- `app-plaid` is not currently included

