### PR TITLE
build: add mount section to fly template

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -11,6 +11,10 @@ processes = []
   allowed_public_ports = []
   auto_rollback = true
 
+[mounts]
+  source="actual_data"
+  destination="/data"
+
 [[services]]
   http_checks = []
   internal_port = 5006


### PR DESCRIPTION
Adds a mount section to the fly template for data persistence. It seems unlikely that there is a case in which one would want to deploy a syncing server but not provide that server with persistence. Providing a mount in the template seems like the saner default.