### PR TITLE
build: add node GC argument to fly template

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -10,6 +10,7 @@ processes = []
 [experimental]
   allowed_public_ports = []
   auto_rollback = true
+  cmd = ["node", "--max-old-space-size=180", "app.js"]
 
 [[services]]
   http_checks = []


### PR DESCRIPTION
Fly deployments on the free tier have ~256mb of memory available. Users with large transaction histories were encountering out of memory errors when attempting to export their data (#54).

This commit adds a node argument to (more or less) run the garbage collector at a smaller memory usage, helping keep users on flyio within their available limit. I think there are additional improvements to be made with the download process, but this config change is also useful.