### PR TITLE
build: add tini subreaper arg to fly template

### DIFF
--- a/fly.template.toml
+++ b/fly.template.toml
@@ -6,6 +6,7 @@ processes = []
 
 [env]
   PORT = "5006"
+  TINI_SUBREAPER = 1
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
Fly deployments with the previous template setting are running without tini's subreaper capabilities (see logs in #54). 

This change enables tini as a subreaper in that environment.