### PR TITLE
ci: add ARMv7 to image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build and push Alpine image
@@ -81,5 +81,5 @@ jobs:
           context: .
           push: true
           file: Dockerfile.alpine
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.alpine-meta.outputs.tags }}


### PR DESCRIPTION
A user reported a desire to run the application on hardware with an ARMv7 architecture. 

This change adds an additional container image to support that need.