### PR TITLE
Fix/download only necessary files

### DIFF
--- a/app-sync.js
+++ b/app-sync.js
@@ -330,7 +330,8 @@ app.get('/download-user-file', async (req, res) => {
 
   let zip = new AdmZip();
   try {
-    zip.addLocalFolder(join(config.userFiles, fileId), '/');
+    zip.addLocalFile(join(config.userFiles, fileId, 'db.sqlite'), '');
+    zip.addLocalFile(join(config.userFiles, fileId, 'metadata.json'), '');
   } catch (e) {
     res.status(500).send('Error reading files');
     return;

--- a/app-sync.js
+++ b/app-sync.js
@@ -136,7 +136,7 @@ app.post('/sync', async (req, res) => {
   let responsePb = new SyncPb.SyncResponse();
   responsePb.setMerkle(JSON.stringify(trie));
 
-  newMessages.forEach(msg => responsePb.addMessages(msg));
+  newMessages.forEach((msg) => responsePb.addMessages(msg));
 
   res.set('Content-Type', 'application/actual-sync');
   res.send(Buffer.from(responsePb.serializeBinary()));
@@ -377,7 +377,7 @@ app.get('/list-user-files', (req, res) => {
   res.send(
     JSON.stringify({
       status: 'ok',
-      data: rows.map(row => ({
+      data: rows.map((row) => ({
         deleted: row.deleted,
         fileId: row.id,
         groupId: row.group_id,


### PR DESCRIPTION
While investigating https://github.com/actualbudget/actual-server/issues/54 it was noted that the previous implementation zips the entire budget folder in the download endpoint. Once received on the client side, only the most recent db and metadata are actually used. This means up to 10 backups (~130mb in some cases) are being zipped in memory and transferred to the client (in addition to the two necessary files) despite none of that data being used. While this inefficiency isn't a major concern in some environments, it may be problematic in memory constrained environments (eg small flyio instances have 256mb total, and can consume half of that *at idle*).

This change transfers only the files that are actually utilized.

If there are other requests to this endpoint that *do* use the backups, this PR will have to be amended. 