### PR TITLE
Switch syncing to simple sync method

### DIFF
--- a/app-sync.js
+++ b/app-sync.js
@@ -126,7 +126,7 @@ app.post('/sync', async (req, res) => {
   // encode it back...
   let responsePb = new SyncPb.SyncResponse();
   responsePb.setMerkle(JSON.stringify(trie));
-  newMessages.forEach(msg => responsePb.addMessages(msg));
+  newMessages.forEach((msg) => responsePb.addMessages(msg));
 
   res.set('Content-Type', 'application/actual-sync');
   res.send(Buffer.from(responsePb.serializeBinary()));
@@ -368,7 +368,7 @@ app.get('/list-user-files', (req, res) => {
   res.send(
     JSON.stringify({
       status: 'ok',
-      data: rows.map(row => ({
+      data: rows.map((row) => ({
         deleted: row.deleted,
         fileId: row.id,
         groupId: row.group_id,

--- a/app-sync.js
+++ b/app-sync.js
@@ -129,6 +129,7 @@ app.post('/sync', async (req, res) => {
   newMessages.forEach((msg) => responsePb.addMessages(msg));
 
   res.set('Content-Type', 'application/actual-sync');
+  res.set('X-ACTUAL-SYNC-METHOD', 'simple');
   res.send(Buffer.from(responsePb.serializeBinary()));
 });
 

--- a/sql/messages.sql
+++ b/sql/messages.sql
@@ -1,10 +1,9 @@
 
 CREATE TABLE messages_binary
-  (timestamp TEXT,
+  (timestamp TEXT PRIMARY KEY,
    is_encrypted BOOLEAN,
-   content bytea,
-   PRIMARY KEY(timestamp, group_id));
+   content bytea);
 
 CREATE TABLE messages_merkles
-  (id TEXT PRIMAREY KEY,
+  (id INTEGER PRIMARY KEY,
    merkle TEXT);

--- a/sync-simple.js
+++ b/sync-simple.js
@@ -57,7 +57,7 @@ function addMessages(db, messages) {
   return returnValue;
 }
 
-function getMerkle(db, group_id) {
+function getMerkle(db) {
   let rows = db.all('SELECT * FROM messages_merkles');
 
   if (rows.length > 0) {
@@ -84,7 +84,7 @@ function sync(messages, since, groupId) {
 
   return {
     trie,
-    newMessages: newMessages.map(msg => {
+    newMessages: newMessages.map((msg) => {
       const envelopePb = new SyncPb.MessageEnvelope();
       envelopePb.setTimestamp(msg.timestamp);
       envelopePb.setIsencrypted(msg.is_encrypted);


### PR DESCRIPTION
**This is a breaking change.** Ideally, users could simply do a "sync reset" and it would just work though.

This PR completely changes how sync data is stored on the server. Previously, I attempted to run a headless version of the entire Actual app. It loads in the full backend of Actual from npm and runs it. The theory was that the app syncing was very stable, given all the stable usage in the closed source version. The server would be just another normal client.

However, the Actual backend hadn't been run on the server like that before, and it wasn't stable. Things like posting schedules is weird to run on the server (and probably shouldn't be). Syncing also hadn't been run as a fully decentralized system. While the algorithm itself totally works like that, there's all kinds of little edge cases when it comes to resetting sync, etc.

**What benefits do we lose?** The simple sync strategy just takes sync messages and stores them in a simple local db. The downside of this is the server can't actually read the data at all. Even if it's not encrypted, it's stored in a way that can't be queried. You could theoretically rebuild the normalized sqlite db from the messages, but it would be a bit heavy. Using the full app meant that we had access to the data and sync events, and you could build workflows like "notify me change a transaction is over X amount". I was thinking that this would be so useful, and doable now that everybody owns their own server (so there's no privacy concerns).

We aren't leveraging those benefits yet, though. I think there's other approaches we could take for it. For now, let's stabilize syncing by switching back to this.

## Migration plan

Once this is merged, all clients won't be able to sync with the new server because the internal sync format has changed. I was really stressing about this, and how to allow people to migrate. Once I got this working and played with it, because it requires no changes in the Actual app itself, I think people should be able to to just a "reset sync" which will completely reset the server state and it'll use this new simple format. Syncing should work from then on with the new format.

Users should still probably export data just in case.

## Syncing will be fixed

I'm very confident this will fix most of the current syncing problems. While looking into this, I realized that the  "sync reset" functionality is currently broken. That's unfortunate because that should be the ultimate escape hatch that wipes out the world and starts fresh, and should always work regardless of syncing problems!
