### PR TITLE
Respect configuration for user-files and don't init the app

### DIFF
--- a/app-sync.js
+++ b/app-sync.js
@@ -16,17 +16,8 @@ let SyncPb = actual.internal.SyncProtoBuf;
 const app = express();
 app.use(errorMiddleware);
 
-async function init() {
-  let fileDir = join(process.env.ACTUAL_USER_FILES || config.userFiles);
-
-  console.log('Initializing Actual with user file dir:', fileDir);
-
-  await actual.init({
-    config: {
-      dataDir: fileDir
-    }
-  });
-}
+// eslint-disable-next-line
+async function init() {}
 
 // This is a version representing the internal format of sync
 // messages. When this changes, all sync files need to be reset. We

--- a/load-config.js
+++ b/load-config.js
@@ -16,4 +16,7 @@ try {
   };
 }
 
+// The env variable always takes precedence
+config.userFiles = process.env.ACTUAL_USER_FILES || config.userFiles;
+
 module.exports = config;

--- a/sync-simple.js
+++ b/sync-simple.js
@@ -1,6 +1,7 @@
 let { existsSync, readFileSync } = require('fs');
 let { join } = require('path');
 let { openDatabase } = require('./db');
+let config = require('./load-config');
 
 let actual = require('@actual-app/api');
 let merkle = actual.internal.merkle;
@@ -8,7 +9,7 @@ let SyncPb = actual.internal.SyncProtoBuf;
 let Timestamp = actual.internal.timestamp.default;
 
 function getGroupDb(groupId) {
-  let path = join(__dirname, `user-files/${groupId}.sqlite`);
+  let path = join(config.userFiles, `${groupId}.sqlite`);
   let needsInit = !existsSync(path);
 
   let db = openDatabase(path);


### PR DESCRIPTION
The new sync method merged in https://github.com/actualbudget/actual-server/pull/75 doesn't respect the `user-files` configuration. I also realized we were still initializing the full Actual app.