### PR TITLE
Store user files as blobs instead of unzipping them

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@actual-app/api": "4.1.0",
     "@actual-app/web": "4.1.0",
-    "adm-zip": "^0.5.9",
     "bcrypt": "^5.0.1",
     "better-sqlite3": "^7.5.0",
     "body-parser": "^1.18.3",

--- a/sync-simple.js
+++ b/sync-simple.js
@@ -1,7 +1,7 @@
 let { existsSync, readFileSync } = require('fs');
 let { join } = require('path');
 let { openDatabase } = require('./db');
-let config = require('./load-config');
+let { getPathForGroupFile } = require('./util/paths');
 
 let actual = require('@actual-app/api');
 let merkle = actual.internal.merkle;
@@ -9,7 +9,7 @@ let SyncPb = actual.internal.SyncProtoBuf;
 let Timestamp = actual.internal.timestamp.default;
 
 function getGroupDb(groupId) {
-  let path = join(config.userFiles, `${groupId}.sqlite`);
+  let path = getPathForGroupFile(groupId);
   let needsInit = !existsSync(path);
 
   let db = openDatabase(path);

--- a/util/paths.js
+++ b/util/paths.js
@@ -1,0 +1,12 @@
+let { join } = require('path');
+let config = require('../load-config');
+
+function getPathForUserFile(fileId) {
+  return join(config.userFiles, `file-${fileId}.blob`);
+}
+
+function getPathForGroupFile(groupId) {
+  return join(config.userFiles, `group-${groupId}.sqlite`);
+}
+
+module.exports = { getPathForUserFile, getPathForGroupFile };

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,11 +201,6 @@ acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
-adm-zip@^0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
-  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
-
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"


### PR DESCRIPTION
This is the last piece needed before releasing the new sync strategy. We should just write down the zip blobs directly instead of unzipping them; this also means we can turn back on e2e encryption if we want.