### PR TITLE
Build docker image on push to master or tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,32 @@
 name: Build Docker Image
 
-# Docker Images are only built when a new tag is created
+# Docker Images are built for every push to master or when a new tag is created
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
+    paths-ignore:
+      - README.md
+      - LICENSE.txt
+
+env:
+  IMAGES: |
+    jlongster/actual-server
+    ghcr.io/actualbudget/actual-server
+
+  # Creates the following tags:
+  # - actual-server:latest (see docker/metadata-action flavor inputs, below)
+  # - actual-server:edge (for master)
+  # - actual-server:1.3
+  # - actual-server:1.3.7
+  # - actual-server:sha-90dd603
+  TAGS: |
+    type=edge
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=sha
 
 jobs:
   build:
@@ -24,35 +46,22 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           # Push to both Docker Hub and Github Container Registry
-          images: |
-            jlongster/actual-server
-            ghcr.io/actualbudget/actual-server
-          # Creates the following tags:
-          # - actual-server:latest
-          # - actual-server:1.3
-          # - actual-server:1.3.7
-          # - actual-server:sha-90dd603
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
+          images: ${{ env.IMAGES }}
+          # Automatically update :latest for our semver tags
+          flavor: |
+            latest=auto
+          tags: ${{ env.TAGS }}
 
       - name: Docker meta for Alpine image
         id: alpine-meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            jlongster/actual-server
-            ghcr.io/actualbudget/actual-server
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,suffix=-alpine
-            type=semver,pattern={{version}},suffix=-alpine
-            type=semver,pattern={{major}}.{{minor}},suffix=-alpine
-            type=sha,suffix=-alpine
+          images: ${{ env.IMAGES }}
+          # Automatically update :latest for our semver tags and suffix all tags
+          flavor: |
+            latest=auto
+            suffix=-alpine,onlatest=true
+          tags: $${{ env.TAGS }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ env:
   # - actual-server:1.3.7
   # - actual-server:sha-90dd603
   TAGS: |
-    type=edge
+    type=edge,value=edge
     type=semver,pattern={{version}}
     type=semver,pattern={{major}}.{{minor}}
     type=sha


### PR DESCRIPTION
~~Facilitates folks trying out any new merged changes, not just ones the project considers "ready for release."
Didn't include here, but we might also consider building on every git tag, since those are rare.~~

PR has changed a lot based on feedback. 
[See below for details](https://github.com/actualbudget/actual-server/pull/82#issuecomment-1276136334).

## Summary
Merging this change will result in Docker images with the following tags being built on every push to `master`:
`edge`
`sha-<commit_sha>`
(as well as the same tags suffixed with `-alpine`)

When a git tag containing `v*.*.*` is pushed to the repo, e.g. `v3.1.4` (or even `v1.2.3-long-description`, see Usage below), the following tagged Docker images will be built:
`latest`
`3.1`
`3.1.4`
`sha-<commit_sha>`
(as well as the same tags suffixed with `-alpine`)

## Usage
* Folks who want bleeding edge code can always use `actual-server:edge` 
* Folks who want a stable Actual can rely on `actual-server:latest`
* Anyone can lock to a specific commit at `actual-server:sha-<commit_sha>`
* Maintainers can push other tags, e.g. `v1.5.6-beta`, `v2.3.0-responsive-preview` as needed and images will be made available for testers