### PR TITLE
Don't public major.minor format of docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,6 @@ env:
   TAGS: |
     type=edge,value=edge
     type=semver,pattern={{version}}
-    type=semver,pattern={{major}}.{{minor}}
     type=sha
 
 jobs:


### PR DESCRIPTION
We don't want `22.12`, we always want the full versioon