### PR TITLE
[WIP] :building_construction:  support typescript code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 **/node_modules/*
 **/log/*
 **/shared/*
+**/build/*
 
 supervise

--- a/account-db.js
+++ b/account-db.js
@@ -1,10 +1,11 @@
-let fs = require('fs');
-let { join } = require('path');
-let { openDatabase } = require('./db');
-let config = require('./load-config');
+import fs from 'fs';
+import { join } from 'path';
+import { openDatabase } from './db';
+import config from './load-config';
+
 let accountDb = null;
 
-function getAccountDb() {
+export function getAccountDb() {
   if (accountDb == null) {
     if (!fs.existsSync(config.serverFiles)) {
       console.log('MAKING SERVER DIR');
@@ -24,5 +25,3 @@ function getAccountDb() {
 
   return accountDb;
 }
-
-module.exports = { getAccountDb };

--- a/app-account.js
+++ b/app-account.js
@@ -1,14 +1,14 @@
-let express = require('express');
-let bcrypt = require('bcrypt');
-let uuid = require('uuid');
-let errorMiddleware = require('./util/error-middleware');
-let { validateUser } = require('./util/validate-user');
-let { getAccountDb } = require('./account-db');
+import express from 'express';
+import bcrypt from 'bcrypt';
+import uuid from 'uuid';
+import errorMiddleware from './util/error-middleware';
+import { validateUser } from './util/validate-user';
+import { getAccountDb } from './account-db';
 
 let app = express();
 app.use(errorMiddleware);
 
-function init() {
+export function init() {
   // eslint-disable-previous-line @typescript-eslint/no-empty-function
 }
 
@@ -112,5 +112,4 @@ app.get('/validate', (req, res) => {
 
 app.use(errorMiddleware);
 
-module.exports.handlers = app;
-module.exports.init = init;
+export const handlers = app;

--- a/app-plaid.js
+++ b/app-plaid.js
@@ -1,14 +1,14 @@
 // This app is unused right now. Maybe you could use it as a starting
 // point for Plaid integration!
 
-const express = require('express');
-const uuid = require('uuid');
-const fetch = require('node-fetch');
-const plaid = require('plaid');
-const { middleware: connectDb } = require('./db');
-const { handleError } = require('./util/handle-error');
-const { validateSubscribedUser } = require('./util/validate-user');
-const config = require('./load-config');
+import express from 'express';
+import uuid from 'uuid';
+import fetch from 'node-fetch';
+import plaid from 'plaid';
+import { middleware as connectDb } from './db';
+import { handleError } from './util/handle-error';
+import { validateSubscribedUser } from './util/validate-user';
+import config from './load-config';
 
 const app = express();
 

--- a/app-sync.js
+++ b/app-sync.js
@@ -1,22 +1,23 @@
-let fs = require('fs/promises');
-let { Buffer } = require('buffer');
-let express = require('express');
-let uuid = require('uuid');
-let { validateUser } = require('./util/validate-user');
-let errorMiddleware = require('./util/error-middleware');
-let { getAccountDb } = require('./account-db');
-let { getPathForUserFile, getPathForGroupFile } = require('./util/paths');
+import fs from 'fs/promises';
+import { Buffer } from 'buffer';
+import express from 'express';
+import uuid from 'uuid';
+import { validateUser } from './util/validate-user';
+import errorMiddleware from './util/error-middleware';
+import { getAccountDb } from './account-db';
+import { getPathForUserFile, getPathForGroupFile } from './util/paths';
 
-let simpleSync = require('./sync-simple');
+import * as simpleSync from './sync-simple';
 
-let actual = require('@actual-app/api');
+import actual from '@actual-app/api';
+
 let SyncPb = actual.internal.SyncProtoBuf;
 
 const app = express();
 app.use(errorMiddleware);
 
 // eslint-disable-next-line
-async function init() {}
+export async function init() {}
 
 // This is a version representing the internal format of sync
 // messages. When this changes, all sync files need to be reset. We
@@ -404,5 +405,4 @@ app.post('/delete-user-file', (req, res) => {
   res.send(JSON.stringify({ status: 'ok' }));
 });
 
-module.exports.handlers = app;
-module.exports.init = init;
+export const handlers = app;

--- a/app-sync.test.js
+++ b/app-sync.test.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const request = require('supertest');
-const { handlers: app } = require('./app-sync');
-const { getAccountDb } = require('./account-db');
-const { getPathForUserFile } = require('./util/paths');
+import fs from 'fs';
+import request from 'supertest';
+import { handlers as app } from './app-sync';
+import { getAccountDb } from './account-db';
+import { getPathForUserFile } from './util/paths';
 
 describe('/download-user-file', () => {
   describe('default version', () => {

--- a/app.js
+++ b/app.js
@@ -1,12 +1,13 @@
-const fs = require('fs');
-const express = require('express');
-const actuator = require('express-actuator');
-const bodyParser = require('body-parser');
-const cors = require('cors');
-const config = require('./load-config');
+import fs from 'fs';
+import path from 'path';
+import express from 'express';
+import actuator from 'express-actuator';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import config from './load-config';
 
-const accountApp = require('./app-account');
-const syncApp = require('./app-sync');
+import * as accountApp from './app-account';
+import * as syncApp from './app-sync';
 
 const app = express();
 
@@ -35,12 +36,19 @@ app.use((req, res, next) => {
   next();
 });
 app.use(
-  express.static(__dirname + '/node_modules/@actual-app/web/build', {
-    index: false
-  })
+  express.static(
+    path.resolve(__dirname + '/../node_modules/@actual-app/web/build'),
+    {
+      index: false
+    }
+  )
 );
 app.get('/*', (req, res) => {
-  res.sendFile(__dirname + '/node_modules/@actual-app/web/build/index.html');
+  res.sendFile(
+    path.resolve(
+      __dirname + '/../node_modules/@actual-app/web/build/index.html'
+    )
+  );
 });
 
 async function run() {

--- a/db.js
+++ b/db.js
@@ -1,4 +1,4 @@
-let Database = require('better-sqlite3');
+import Database from 'better-sqlite3';
 
 class WrappedDatabase {
   constructor(db) {
@@ -34,8 +34,6 @@ class WrappedDatabase {
   }
 }
 
-function openDatabase(filename) {
+export function openDatabase(filename) {
   return new WrappedDatabase(new Database(filename));
 }
-
-module.exports = { openDatabase };

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,4 +1,10 @@
 {
-	"setupFiles": ["./jest.setup.js"],
-	"testPathIgnorePatterns": ["/node_modules/", "/build/"]
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "transform": {
+    "^.+\\.jsx?$": ["ts-jest"],
+    "^.+\\.tsx?$": ["ts-jest"]
+  },
+  "setupFiles": ["./jest.setup.js"],
+  "testPathIgnorePatterns": ["/node_modules/", "/build/"]
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const { join } = require('path');
 const { getAccountDb } = require('./account-db');
-const config = require('./load-config');
+const { default: config } = require('./load-config');
 
 // Delete previous test database (force creation of a new one)
 const dbPath = join(config.serverFiles, 'account.sqlite');

--- a/load-config.js
+++ b/load-config.js
@@ -1,6 +1,7 @@
+import fs from 'fs';
+import { join } from 'path';
+
 let config = {};
-let fs = require('fs');
-let { join } = require('path');
 let root = fs.existsSync('/data') ? '/data' : __dirname;
 
 try {
@@ -23,8 +24,8 @@ if (process.env.NODE_ENV === 'test') {
     mode: 'development',
     port: 5006,
     hostname: '::',
-    serverFiles: join(root, 'server-files'),
-    userFiles: join(root, 'user-files'),
+    serverFiles: join(root, '../server-files'),
+    userFiles: join(root, '../user-files'),
     ...config
   };
 }
@@ -32,4 +33,4 @@ if (process.env.NODE_ENV === 'test') {
 // The env variable always takes precedence
 config.userFiles = process.env.ACTUAL_USER_FILES || config.userFiles;
 
-module.exports = config;
+export default config;

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "23.1.12",
   "license": "MIT",
   "description": "actual syncing server",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
-    "start": "node app",
+    "start": "concurrently \"npx tsc --watch\" \"nodemon -q build/app.js\"",
     "lint": "eslint .",
     "build": "tsc",
     "test": "jest",
@@ -27,16 +27,19 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.5.0",
-    "@types/jest": "^29.2.3",
+    "@types/jest": "^29.4.0",
     "@types/node": "^17.0.31",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
+    "concurrently": "^7.6.0",
     "eslint": "^8.15.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "jest": "^29.3.1",
+    "jest": "^29.4.1",
+    "nodemon": "^2.0.20",
     "prettier": "^2.6.2",
     "supertest": "^6.3.1",
+    "ts-jest": "^29.0.5",
     "typescript": "^4.6.4"
   },
   "packageManager": "yarn@3.2.1"

--- a/sync-full.js
+++ b/sync-full.js
@@ -1,6 +1,7 @@
-let { sequential } = require('./util/async');
+import { sequential } from './util/async';
 
-let actual = require('@actual-app/api');
+import actual from '@actual-app/api';
+
 let SyncPb = actual.internal.SyncProtoBuf;
 
 // This method must be sequential (TODO: document why, because Actual
@@ -50,4 +51,4 @@ const sync = sequential(async function syncAPI(messages, since, fileId) {
   };
 });
 
-module.exports = { sync };
+export default sync;

--- a/sync-simple.js
+++ b/sync-simple.js
@@ -1,9 +1,10 @@
-let { existsSync, readFileSync } = require('fs');
-let { join } = require('path');
-let { openDatabase } = require('./db');
-let { getPathForGroupFile } = require('./util/paths');
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { openDatabase } from './db';
+import { getPathForGroupFile } from './util/paths';
 
-let actual = require('@actual-app/api');
+import actual from '@actual-app/api';
+
 let merkle = actual.internal.merkle;
 let SyncPb = actual.internal.SyncProtoBuf;
 let Timestamp = actual.internal.timestamp.Timestamp;
@@ -15,7 +16,7 @@ function getGroupDb(groupId) {
   let db = openDatabase(path);
 
   if (needsInit) {
-    let sql = readFileSync(join(__dirname, 'sql/messages.sql'), 'utf8');
+    let sql = readFileSync(join(__dirname, '/../sql/messages.sql'), 'utf8');
     db.exec(sql);
   }
 
@@ -70,7 +71,7 @@ function getMerkle(db) {
   }
 }
 
-function sync(messages, since, groupId) {
+export function sync(messages, since, groupId) {
   let db = getGroupDb(groupId);
   let newMessages = db.all(
     `SELECT * FROM messages_binary
@@ -94,5 +95,3 @@ function sync(messages, since, groupId) {
     })
   };
 }
-
-module.exports = { sync };

--- a/util/async.js
+++ b/util/async.js
@@ -1,4 +1,4 @@
-function sequential(fn) {
+export function sequential(fn) {
   let sequenceState = {
     running: null,
     queue: []
@@ -40,5 +40,3 @@ function sequential(fn) {
     }
   };
 }
-
-module.exports = { sequential };

--- a/util/error-middleware.js
+++ b/util/error-middleware.js
@@ -1,6 +1,4 @@
-async function middleware(err, req, res, _next) {
+export default async function middleware(err, req, res, _next) {
   console.log('ERROR', err);
   res.status(500).send({ status: 'error', reason: 'internal-error' });
 }
-
-module.exports = middleware;

--- a/util/handle-error.js
+++ b/util/handle-error.js
@@ -1,4 +1,4 @@
-function handleError(func) {
+export function handleError(func) {
   return (req, res) => {
     func(req, res).catch((err) => {
       console.log('Error', req.originalUrl, err);
@@ -7,5 +7,3 @@ function handleError(func) {
     });
   };
 }
-
-module.exports = { handleError };

--- a/util/paths.js
+++ b/util/paths.js
@@ -1,12 +1,10 @@
-let { join } = require('path');
-let config = require('../load-config');
+import { join } from 'path';
+import config from '../load-config';
 
-function getPathForUserFile(fileId) {
+export function getPathForUserFile(fileId) {
   return join(config.userFiles, `file-${fileId}.blob`);
 }
 
-function getPathForGroupFile(groupId) {
+export function getPathForGroupFile(groupId) {
   return join(config.userFiles, `group-${groupId}.sqlite`);
 }
-
-module.exports = { getPathForUserFile, getPathForGroupFile };

--- a/util/validate-user.js
+++ b/util/validate-user.js
@@ -1,6 +1,6 @@
-let { getAccountDb } = require('../account-db');
+import { getAccountDb } from '../account-db';
 
-function validateUser(req, res) {
+export function validateUser(req, res) {
   let { token } = req.body || {};
 
   if (!token) {
@@ -22,5 +22,3 @@ function validateUser(req, res) {
 
   return rows[0];
 }
-
-module.exports = { validateUser };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,7 +1285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^29.2.3":
+"@types/jest@npm:^29.4.0":
   version: 29.4.0
   resolution: "@types/jest@npm:29.4.0"
   dependencies:
@@ -1517,7 +1517,7 @@ __metadata:
     "@actual-app/api": 4.1.5
     "@actual-app/web": 23.1.12
     "@types/better-sqlite3": ^7.5.0
-    "@types/jest": ^29.2.3
+    "@types/jest": ^29.4.0
     "@types/node": ^17.0.31
     "@types/supertest": ^2.0.12
     "@typescript-eslint/eslint-plugin": ^5.23.0
@@ -1525,16 +1525,19 @@ __metadata:
     bcrypt: ^5.0.1
     better-sqlite3: ^7.5.0
     body-parser: ^1.18.3
+    concurrently: ^7.6.0
     cors: ^2.8.5
     eslint: ^8.15.0
     eslint-plugin-prettier: ^4.0.0
     express: 4.17
     express-actuator: ^1.8.1
     express-response-size: ^0.0.3
-    jest: ^29.3.1
+    jest: ^29.4.1
     node-fetch: ^2.6.7
+    nodemon: ^2.0.20
     prettier: ^2.6.2
     supertest: ^6.3.1
+    ts-jest: ^29.0.5
     typescript: ^4.6.4
     uuid: ^3.3.2
   languageName: unknown
@@ -1637,7 +1640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3":
+"anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -1846,6 +1849,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "binary-extensions@npm:2.2.0"
+  checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
 "bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -1941,7 +1951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
+"braces@npm:^3.0.2, braces@npm:~3.0.2":
   version: 3.0.2
   resolution: "braces@npm:3.0.2"
   dependencies:
@@ -1961,6 +1971,15 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 4af3793704dbb4615bcd29059ab472344dc7961c8680aa6c4bb84f05340e14038d06a5aead58724eae69455b8fade8b8c69f1638016e87e5578969d74c078b79
+  languageName: node
+  linkType: hard
+
+"bs-logger@npm:0.x":
+  version: 0.2.6
+  resolution: "bs-logger@npm:0.2.6"
+  dependencies:
+    fast-json-stable-stringify: 2.x
+  checksum: d34bdaf68c64bd099ab97c3ea608c9ae7d3f5faa1178b3f3f345acd94e852e608b2d4f9103fb2e503f5e69780e98293df41691b84be909b41cf5045374d54606
   languageName: node
   linkType: hard
 
@@ -2079,7 +2098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2093,6 +2112,25 @@ __metadata:
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
   checksum: b563e4b6039b15213114626621e7a3d12f31008bdce20f9c741d69987f62aeaace7ec30f6018890ad77b2e9b4d95324c9f5acfca58a9441e3b1dcdd1e2525d17
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^3.5.2":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -2234,6 +2272,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concurrently@npm:^7.6.0":
+  version: 7.6.0
+  resolution: "concurrently@npm:7.6.0"
+  dependencies:
+    chalk: ^4.1.0
+    date-fns: ^2.29.1
+    lodash: ^4.17.21
+    rxjs: ^7.0.0
+    shell-quote: ^1.7.3
+    spawn-command: ^0.0.2-1
+    supports-color: ^8.1.0
+    tree-kill: ^1.2.2
+    yargs: ^17.3.1
+  bin:
+    conc: dist/bin/concurrently.js
+    concurrently: dist/bin/concurrently.js
+  checksum: f705c9a7960f1b16559ca64958043faeeef6385c0bf30a03d1375e15ab2d96dba4f8166f1bbbb1c85e8da35ca0ce3c353875d71dff2aa132b2357bb533b3332e
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
@@ -2327,6 +2385,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^2.29.1":
+  version: 2.29.3
+  resolution: "date-fns@npm:2.29.3"
+  checksum: e01cf5b62af04e05dfff921bb9c9933310ed0e1ae9a81eb8653452e64dc841acf7f6e01e1a5ae5644d0337e9a7f936175fd2cb6819dc122fdd9c5e86c56be484
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -2345,6 +2410,15 @@ __metadata:
     supports-color:
       optional: true
   checksum: 820ea160e267e23c953c9ed87e7ad93494d8cda2f7349af5e7e3bb236d23707ee3022f477d5a7d2ee86ef2bf7d60aa9ab22d1f58080d7deb9dccd073585e1e43
+  languageName: node
+  linkType: hard
+
+"debug@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
+  dependencies:
+    ms: ^2.1.1
+  checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
   languageName: node
   linkType: hard
 
@@ -2948,17 +3022,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "fast-json-stable-stringify@npm:2.1.0"
+  checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
+  languageName: node
+  linkType: hard
+
 "fast-json-stable-stringify@npm:^2.0.0":
   version: 2.0.0
   resolution: "fast-json-stable-stringify@npm:2.0.0"
   checksum: 5f776089e60a20ccdf5fd17c90590a4bb7c04c4240b2ffde1caad3949f7876a57af7094323dcb432fa6534367768ac6c6b5433a16c5241d0e2cdf0b51b7d4c9f
-  languageName: node
-  linkType: hard
-
-"fast-json-stable-stringify@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "fast-json-stable-stringify@npm:2.1.0"
-  checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
   languageName: node
   linkType: hard
 
@@ -3136,7 +3210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -3146,7 +3220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=18f3a7"
   dependencies:
@@ -3264,7 +3338,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.2":
+"glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -3536,6 +3610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore-by-default@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "ignore-by-default@npm:1.0.1"
+  checksum: 441509147b3615e0365e407a3c18e189f78c07af08564176c680be1fabc94b6c789cad1342ad887175d4ecd5225de86f73d376cec8e06b42fd9b429505ffcf8a
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.1.8, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
@@ -3660,6 +3741,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-binary-path@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "is-binary-path@npm:2.1.0"
+  dependencies:
+    binary-extensions: ^2.0.0
+  checksum: 84192eb88cff70d320426f35ecd63c3d6d495da9d805b19bc65b518984b7c0760280e57dbf119b7e9be6b161784a5a673ab2c6abe83abb5198a432232ad5b35c
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.9.0":
   version: 2.11.0
   resolution: "is-core-module@npm:2.11.0"
@@ -3706,7 +3796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -4177,7 +4267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.4.1":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.4.1":
   version: 29.4.1
   resolution: "jest-util@npm:29.4.1"
   dependencies:
@@ -4233,7 +4323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.3.1":
+"jest@npm:^29.4.1":
   version: 29.4.1
   resolution: "jest@npm:29.4.1"
   dependencies:
@@ -4312,7 +4402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.2":
+"json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -4361,10 +4451,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.memoize@npm:4.x":
+  version: 4.1.2
+  resolution: "lodash.memoize@npm:4.1.2"
+  checksum: 9ff3942feeccffa4f1fafa88d32f0d24fdc62fd15ded5a74a5f950ff5f0c6f61916157246744c620173dddf38d37095a92327d5fd3861e2063e736a5c207d089
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
   languageName: node
   linkType: hard
 
@@ -4399,6 +4503,13 @@ __metadata:
   dependencies:
     semver: ^6.0.0
   checksum: 484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+  languageName: node
+  linkType: hard
+
+"make-error@npm:1.x":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
   languageName: node
   linkType: hard
 
@@ -4694,7 +4805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0":
+"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -4812,6 +4923,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nodemon@npm:^2.0.20":
+  version: 2.0.20
+  resolution: "nodemon@npm:2.0.20"
+  dependencies:
+    chokidar: ^3.5.2
+    debug: ^3.2.7
+    ignore-by-default: ^1.0.1
+    minimatch: ^3.1.2
+    pstree.remy: ^1.1.8
+    semver: ^5.7.1
+    simple-update-notifier: ^1.0.7
+    supports-color: ^5.5.0
+    touch: ^3.1.0
+    undefsafe: ^2.0.5
+  bin:
+    nodemon: bin/nodemon.js
+  checksum: 9fe858682414fe703179f4fe36c86e71f40d2693b5345c09803d7b191816a6589c5df8f1f9873bffee92893880183b95a031c86340e46b364ef1b0b7f619edbf
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -4834,7 +4965,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0":
+"nopt@npm:~1.0.10":
+  version: 1.0.10
+  resolution: "nopt@npm:1.0.10"
+  dependencies:
+    abbrev: 1
+  bin:
+    nopt: ./bin/nopt.js
+  checksum: f62575aceaa3be43f365bf37a596b89bbac2e796b001b6d2e2a85c2140a4e378ff919e2753ccba959c4fd344776fc88c29b393bc167fa939fb1513f126f4cd45
+  languageName: node
+  linkType: hard
+
+"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
@@ -5084,7 +5226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
@@ -5216,6 +5358,13 @@ __metadata:
     forwarded: 0.2.0
     ipaddr.js: 1.9.1
   checksum: 29c6990ce9364648255454842f06f8c46fcd124d3e6d7c5066df44662de63cdc0bad032e9bf5a3d653ff72141cc7b6019873d685708ac8210c30458ad99f2b74
+  languageName: node
+  linkType: hard
+
+"pstree.remy@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "pstree.remy@npm:1.1.8"
+  checksum: 5cb53698d6bb34dfb278c8a26957964aecfff3e161af5fbf7cee00bbe9d8547c7aced4bd9cb193bce15fb56e9e4220fc02a5bf9c14345ffb13a36b858701ec2d
   languageName: node
   linkType: hard
 
@@ -5390,6 +5539,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
+  dependencies:
+    picomatch: ^2.2.1
+  checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
+  languageName: node
+  linkType: hard
+
 "regenerator-runtime@npm:^0.13.11":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
@@ -5501,6 +5659,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.0.0":
+  version: 7.8.0
+  resolution: "rxjs@npm:7.8.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -5519,6 +5686,26 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.x, semver@npm:^7.3.8":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
+  languageName: node
+  linkType: hard
+
+"semver@npm:^5.7.1":
+  version: 5.7.1
+  resolution: "semver@npm:5.7.1"
+  bin:
+    semver: ./bin/semver
+  checksum: 57fd0acfd0bac382ee87cd52cd0aaa5af086a7dc8d60379dfe65fea491fb2489b6016400813930ecd61fd0952dae75c115287a1b16c234b1550887117744dfaf
   languageName: node
   linkType: hard
 
@@ -5542,14 +5729,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.8":
-  version: 7.3.8
-  resolution: "semver@npm:7.3.8"
-  dependencies:
-    lru-cache: ^6.0.0
+"semver@npm:~7.0.0":
+  version: 7.0.0
+  resolution: "semver@npm:7.0.0"
   bin:
     semver: bin/semver.js
-  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
+  checksum: 272c11bf8d083274ef79fe40a81c55c184dff84dd58e3c325299d0927ba48cece1f020793d138382b85f89bab5002a35a5ba59a3a68a7eebbb597eb733838778
   languageName: node
   linkType: hard
 
@@ -5656,6 +5841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shell-quote@npm:^1.7.3":
+  version: 1.8.0
+  resolution: "shell-quote@npm:1.8.0"
+  checksum: 6ef7c5e308b9c77eedded882653a132214fa98b4a1512bb507588cf6cd2fc78bfee73e945d0c3211af028a1eabe09c6a19b96edd8977dc149810797e93809749
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -5696,6 +5888,15 @@ __metadata:
     once: ^1.3.1
     simple-concat: ^1.0.0
   checksum: e4132fd27cf7af230d853fa45c1b8ce900cb430dd0a3c6d3829649fe4f2b26574c803698076c4006450efb0fad2ba8c5455fbb5755d4b0a5ec42d4f12b31d27e
+  languageName: node
+  linkType: hard
+
+"simple-update-notifier@npm:^1.0.7":
+  version: 1.1.0
+  resolution: "simple-update-notifier@npm:1.1.0"
+  dependencies:
+    semver: ~7.0.0
+  checksum: 1012e9b6c504e559a948078177b3eedbb9d7e4d15878e2bda56314d08db609ca5da485be4ac9f838759faae8057935ee0246fcdf63f1233c86bd9fecb2a5544b
   languageName: node
   linkType: hard
 
@@ -5755,6 +5956,13 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
+"spawn-command@npm:^0.0.2-1":
+  version: 0.0.2
+  resolution: "spawn-command@npm:0.0.2"
+  checksum: e35c5d28177b4d461d33c88cc11f6f3a5079e2b132c11e1746453bbb7a0c0b8a634f07541a2a234fa4758239d88203b758def509161b651e81958894c0b4b64b
   languageName: node
   linkType: hard
 
@@ -5940,7 +6148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0":
+"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:
@@ -5958,7 +6166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
+"supports-color@npm:^8.0.0, supports-color@npm:^8.1.0":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -6075,6 +6283,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"touch@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "touch@npm:3.1.0"
+  dependencies:
+    nopt: ~1.0.10
+  bin:
+    nodetouch: ./bin/nodetouch.js
+  checksum: e0be589cb5b0e6dbfce6e7e077d4a0d5f0aba558ef769c6d9c33f635e00d73d5be49da6f8631db302ee073919d82b5b7f56da2987feb28765c95a7673af68647
+  languageName: node
+  linkType: hard
+
 "tr46@npm:~0.0.3":
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
@@ -6082,10 +6301,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-kill@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.0.5":
+  version: 29.0.5
+  resolution: "ts-jest@npm:29.0.5"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.3
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: f60f129c2287f4c963d9ee2677132496c5c5a5d39c27ad234199a1140c26318a7d5bda34890ab0e30636ec42a8de28f84487c09e9dcec639c9c67812b3a38373
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0":
+  version: 2.5.0
+  resolution: "tslib@npm:2.5.0"
+  checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
   languageName: node
   linkType: hard
 
@@ -6183,6 +6451,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1cb434fbc637d347be90e3a0c6cd05e33c38f941713c8786d3031faf1842c2c148ba91d2fac01e7276b0ae3249b8633f1660e32686cc7a8c6a8fd5361dc52c66
+  languageName: node
+  linkType: hard
+
+"undefsafe@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "undefsafe@npm:2.0.5"
+  checksum: f42ab3b5770fedd4ada175fc1b2eb775b78f609156f7c389106aafd231bfc210813ee49f54483d7191d7b76e483bc7f537b5d92d19ded27156baf57592eb02cc
   languageName: node
   linkType: hard
 
@@ -6393,7 +6668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c


### PR DESCRIPTION
A few changes in this PR to facilitate migration to TypeScript.

1. Tooling setup to allow developing with TS files
2. Changing imports/exports to be more modern
3. Changing some file paths now that files are served from `./build` folder instead of `.`

**Why do this?**

Upgrading some dependencies with security issues (such as node-fetch) requires using modern import syntax. So we might as well continue the TS migration here..