### PR TITLE
Improve the server config

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,8 +55,12 @@ async function run() {
     const https = require('https');
     const httpsOptions = {
       ...config.https,
-      key: fs.readFileSync(config.https.key),
-      cert: fs.readFileSync(config.https.cert)
+      key: config.https.key.startsWith('-----BEGIN')
+        ? config.https.key
+        : fs.readFileSync(config.https.key),
+      cert: config.https.cert.startsWith('-----BEGIN')
+        ? config.https.cert
+        : fs.readFileSync(config.https.cert)
     };
     https.createServer(httpsOptions, app).listen(config.port, config.hostname);
   } else {

--- a/app.js
+++ b/app.js
@@ -35,9 +35,9 @@ app.use((req, res, next) => {
   next();
 });
 app.use(express.static(config.webRoot, { index: false }));
-app.get('/*', (req, res) => {
-  res.sendFile(config.webRoot + '/index.html');
-});
+
+let indexHTML = fs.readFileSync(config.webRoot + '/index.html');
+app.get('/*', (req, res) => res.send(indexHTML));
 
 async function run() {
   if (!fs.existsSync(config.serverFiles)) {

--- a/app.js
+++ b/app.js
@@ -51,7 +51,6 @@ async function run() {
   await accountApp.init();
   await syncApp.init();
 
-  console.log('Listening on ' + config.hostname + ':' + config.port + '...');
   if (config.https) {
     const https = require('https');
     const httpsOptions = {
@@ -63,6 +62,7 @@ async function run() {
   } else {
     app.listen(config.port, config.hostname);
   }
+  console.log('Listening on ' + config.hostname + ':' + config.port + '...');
 }
 
 run().catch((err) => {

--- a/app.js
+++ b/app.js
@@ -34,13 +34,9 @@ app.use((req, res, next) => {
   res.set('Cross-Origin-Embedder-Policy', 'require-corp');
   next();
 });
-app.use(
-  express.static(__dirname + '/node_modules/@actual-app/web/build', {
-    index: false
-  })
-);
+app.use(express.static(config.webRoot, { index: false }));
 app.get('/*', (req, res) => {
-  res.sendFile(__dirname + '/node_modules/@actual-app/web/build/index.html');
+  res.sendFile(config.webRoot + '/index.html');
 });
 
 async function run() {

--- a/config-types.ts
+++ b/config-types.ts
@@ -1,0 +1,12 @@
+export interface Config {
+  mode: 'test' | 'development';
+  port: number;
+  hostname: string;
+  serverFiles: string;
+  userFiles: string;
+  webRoot: string;
+  https?: {
+    key: string;
+    cert: string;
+  } & Parameters<typeof import('node:https')['createServer']>[0];
+}

--- a/load-config.js
+++ b/load-config.js
@@ -10,21 +10,22 @@ try {
   // do nothing
 }
 
+let defaultConfig = {
+  port: 5006,
+  hostname: '::',
+  serverFiles: join(root, 'server-files'),
+  userFiles: join(root, 'user-files'),
+  webRoot: join(__dirname, 'node_modules', '@actual-app', 'web', 'build')
+};
 if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'test',
-    port: 5006,
-    hostname: '::',
-    serverFiles: join(__dirname, 'test-server-files'),
-    userFiles: join(__dirname, 'test-user-files')
+    ...defaultConfig
   };
 } else {
   config = {
     mode: 'development',
-    port: 5006,
-    hostname: '::',
-    serverFiles: join(root, 'server-files'),
-    userFiles: join(root, 'user-files'),
+    ...defaultConfig,
     ...config
   };
 }

--- a/load-config.js
+++ b/load-config.js
@@ -36,7 +36,7 @@ if (process.env.NODE_ENV === 'test') {
     ...defaultConfig,
     serverFiles: join(root, 'server-files'),
     userFiles: join(root, 'user-files'),
-    ...userConfig
+    ...(userConfig || {})
   };
 }
 

--- a/load-config.js
+++ b/load-config.js
@@ -3,11 +3,15 @@ let fs = require('fs');
 let { join } = require('path');
 let root = fs.existsSync('/data') ? '/data' : __dirname;
 
-try {
-  // @ts-expect-error TS2307: we expect this file may not exist
-  userConfig = require('./config');
-} catch (e) {
-  // do nothing
+if (process.env.ACTUAL_CONFIG_PATH) {
+  userConfig = require(process.env.ACTUAL_CONFIG_PATH);
+} else {
+  try {
+    // @ts-expect-error TS2307: we expect this file may not exist
+    userConfig = require('./config');
+  } catch (e) {
+    // do nothing
+  }
 }
 
 /** @type {Omit<import('./config-types').Config, 'mode' | 'serverFiles' | 'userFiles'>} */

--- a/load-config.js
+++ b/load-config.js
@@ -48,7 +48,7 @@ module.exports = {
       ? {
           key: process.env.ACTUAL_HTTPS_KEY,
           cert: process.env.ACTUAL_HTTPS_CERT,
-          ...config.https
+          ...(config.https || {})
         }
       : config.https
 };

--- a/load-config.js
+++ b/load-config.js
@@ -10,12 +10,10 @@ try {
   // do nothing
 }
 
-/** @type {Omit<import('./config-types').Config, 'mode'>} */
+/** @type {Omit<import('./config-types').Config, 'mode' | 'serverFiles' | 'userFiles'>} */
 let defaultConfig = {
   port: 5006,
   hostname: '::',
-  serverFiles: join(root, 'server-files'),
-  userFiles: join(root, 'user-files'),
   webRoot: join(__dirname, 'node_modules', '@actual-app', 'web', 'build')
 };
 
@@ -24,12 +22,16 @@ let config;
 if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'test',
+    serverFiles: join(__dirname, 'test-server-files'),
+    userFiles: join(__dirname, 'test-user-files'),
     ...defaultConfig
   };
 } else {
   config = {
     mode: 'development',
     ...defaultConfig,
+    serverFiles: join(root, 'server-files'),
+    userFiles: join(root, 'user-files'),
     ...userConfig
   };
 }

--- a/load-config.js
+++ b/load-config.js
@@ -31,6 +31,16 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 // The env variable always takes precedence
+config.port = process.env.ACTUAL_PORT || process.env.PORT || config.port;
+config.hostname = process.env.ACTUAL_HOSTNAME || config.hostname;
+config.serverFiles = process.env.ACTUAL_SERVER_FILES || config.serverFiles;
 config.userFiles = process.env.ACTUAL_USER_FILES || config.userFiles;
+config.webRoot = process.env.ACTUAL_WEB_ROOT || config.webRoot;
+if (process.env.ACTUAL_HTTPS_KEY && process.env.ACTUAL_HTTPS_CERT) {
+  config.https = {
+    key: process.env.ACTUAL_HTTPS_KEY,
+    cert: process.env.ACTUAL_HTTPS_CERT
+  };
+}
 
 module.exports = config;

--- a/load-config.js
+++ b/load-config.js
@@ -1,15 +1,16 @@
-let config = {};
+let userConfig;
 let fs = require('fs');
 let { join } = require('path');
 let root = fs.existsSync('/data') ? '/data' : __dirname;
 
 try {
   // @ts-expect-error TS2307: we expect this file may not exist
-  config = require('./config');
+  userConfig = require('./config');
 } catch (e) {
   // do nothing
 }
 
+/** @type {Omit<import('./config-types').Config, 'mode'>} */
 let defaultConfig = {
   port: 5006,
   hostname: '::',
@@ -17,6 +18,9 @@ let defaultConfig = {
   userFiles: join(root, 'user-files'),
   webRoot: join(__dirname, 'node_modules', '@actual-app', 'web', 'build')
 };
+
+/** @type {import('./config-types').Config} */
+let config;
 if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'test',
@@ -26,21 +30,23 @@ if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'development',
     ...defaultConfig,
-    ...config
+    ...userConfig
   };
 }
 
-// The env variable always takes precedence
-config.port = process.env.ACTUAL_PORT || process.env.PORT || config.port;
-config.hostname = process.env.ACTUAL_HOSTNAME || config.hostname;
-config.serverFiles = process.env.ACTUAL_SERVER_FILES || config.serverFiles;
-config.userFiles = process.env.ACTUAL_USER_FILES || config.userFiles;
-config.webRoot = process.env.ACTUAL_WEB_ROOT || config.webRoot;
-if (process.env.ACTUAL_HTTPS_KEY && process.env.ACTUAL_HTTPS_CERT) {
-  config.https = {
-    key: process.env.ACTUAL_HTTPS_KEY,
-    cert: process.env.ACTUAL_HTTPS_CERT
-  };
-}
-
-module.exports = config;
+module.exports = {
+  ...config,
+  port: +process.env.ACTUAL_PORT || +process.env.PORT || config.port,
+  hostname: process.env.ACTUAL_HOSTNAME || config.hostname,
+  serverFiles: process.env.ACTUAL_SERVER_FILES || config.serverFiles,
+  userFiles: process.env.ACTUAL_USER_FILES || config.userFiles,
+  webRoot: process.env.ACTUAL_WEB_ROOT || config.webRoot,
+  https:
+    process.env.ACTUAL_HTTPS_KEY && process.env.ACTUAL_HTTPS_CERT
+      ? {
+          key: process.env.ACTUAL_HTTPS_KEY,
+          cert: process.env.ACTUAL_HTTPS_CERT,
+          ...config.https
+        }
+      : config.https
+};


### PR DESCRIPTION
- Now all config properties can be set via environment variables (will PR the docs to add them there too!)
- a new `webRoot` config property allows you to skip using the web UI installed from npm and instead use a different version. The only requirement is that it has an `index.html`.