### PR TITLE
Fix / route returning the wrong MIME type

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,8 +36,7 @@ app.use((req, res, next) => {
 });
 app.use(express.static(config.webRoot, { index: false }));
 
-let indexHTML = fs.readFileSync(config.webRoot + '/index.html');
-app.get('/*', (req, res) => res.send(indexHTML));
+app.get('/*', (req, res) => res.sendFile(config.webRoot + '/index.html'));
 
 async function run() {
   if (!fs.existsSync(config.serverFiles)) {


### PR DESCRIPTION
\*shakes fist at CodeQL for suggesting changing this code\*

I didn’t test the change in 58d13003d32ca25d333d67a30b7e96bd2c367e40 thoroughly enough, sorry!

Fixes #126