### PR TITLE
Replace '\n' in key/cert text with literal newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,16 @@ Now we need to tell Actual to use this volume. Add this in `fly.toml`:
 
 That's it! Actual will automatically check if the `/data` directory exists and use it automatically.
 
-_You can also configure the data dir with the `ACTUAL_USER_FILES` environment variable._
-
 
 ### One-click hosting solutions
 
 These are non-official methods of one-click solutions for running Actual. If you provide a service like this, feel free to open a PR and add it to this list. These run Actual via a Docker image.
 
 * PikaPods: [Run on PikaPods](https://www.pikapods.com/pods?run=actual)
+
+## Configuring the server
+
+The server accepts several configuration options, including for HTTPS certificates and various file paths. The documentation website has [a page dedicated to configuration options](https://actualbudget.github.io/docs/Installing/Configuration)
 
 ## Configuring the server URL
 

--- a/app.js
+++ b/app.js
@@ -38,6 +38,13 @@ app.use(express.static(config.webRoot, { index: false }));
 
 app.get('/*', (req, res) => res.sendFile(config.webRoot + '/index.html'));
 
+function parseHTTPSConfig(value) {
+  if (value.startsWith('-----BEGIN')) {
+    return value.replace(/\\n/g, '\n');
+  }
+  return fs.readFileSync(value);
+}
+
 async function run() {
   if (!fs.existsSync(config.serverFiles)) {
     fs.mkdirSync(config.serverFiles);
@@ -54,12 +61,8 @@ async function run() {
     const https = require('https');
     const httpsOptions = {
       ...config.https,
-      key: config.https.key.startsWith('-----BEGIN')
-        ? config.https.key
-        : fs.readFileSync(config.https.key),
-      cert: config.https.cert.startsWith('-----BEGIN')
-        ? config.https.cert
-        : fs.readFileSync(config.https.cert)
+      key: parseHTTPSConfig(config.https.key),
+      cert: parseHTTPSConfig(config.https.cert)
     };
     https.createServer(httpsOptions, app).listen(config.port, config.hostname);
   } else {

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ app.get('/*', (req, res) => res.sendFile(config.webRoot + '/index.html'));
 
 function parseHTTPSConfig(value) {
   if (value.startsWith('-----BEGIN')) {
-    return value.replace(/\\n/g, '\n');
+    return value;
   }
   return fs.readFileSync(value);
 }

--- a/load-config.js
+++ b/load-config.js
@@ -50,8 +50,8 @@ module.exports = {
   https:
     process.env.ACTUAL_HTTPS_KEY && process.env.ACTUAL_HTTPS_CERT
       ? {
-          key: process.env.ACTUAL_HTTPS_KEY,
-          cert: process.env.ACTUAL_HTTPS_CERT,
+          key: process.env.ACTUAL_HTTPS_KEY.replace(/\\n/g, '\n'),
+          cert: process.env.ACTUAL_HTTPS_CERT.replace(/\\n/g, '\n'),
           ...(config.https || {})
         }
       : config.https


### PR DESCRIPTION
This makes it easier to specify them as an environment variable (where you might not be able to enter a multiline string). It does not apply to the contents of a file pointed to by the config, or to the values in `config.json`.