### PR TITLE
Replace require with import

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,7 @@ export default async function run() {
   await syncApp.init();
 
   if (config.https) {
-    const https = require('https');
+    const https = await import('node:https');
     const httpsOptions = {
       ...config.https,
       key: parseHTTPSConfig(config.https.key),


### PR DESCRIPTION
This fixes an issue where the server would fail to start up when HTTPS was enabled, since ES Modules no longer support calling `require()` inside of them directly. I checked the rest of the code and there don’t seem to be any other `require` calls.