### PR TITLE
Auto-configure the client’s server URL

### DIFF
--- a/src/app-account.js
+++ b/src/app-account.js
@@ -30,10 +30,7 @@ app.get('/needs-bootstrap', (req, res) => {
 
   res.send({
     status: 'ok',
-    data: {
-      isActual: true,
-      bootstrapped: rows.length > 0
-    }
+    data: { bootstrapped: rows.length > 0 }
   });
 });
 

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -20,6 +20,7 @@ function hashPassword(password) {
 
 // Non-authenticated endpoints:
 //
+// /needs-bootstrap
 // /boostrap (special endpoint for setting up the instance, cant call again)
 // /login
 

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -29,7 +29,10 @@ app.get('/needs-bootstrap', (req, res) => {
 
   res.send({
     status: 'ok',
-    data: { bootstrapped: rows.length > 0 }
+    data: {
+      isActual: true,
+      bootstrapped: rows.length > 0
+    }
   });
 });
 

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,13 @@ app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '50mb' }));
 app.use('/sync', syncApp.handlers);
 app.use('/account', accountApp.handlers);
 
+app.get('/client-bootstrap', (req, res) => {
+  // can also return a `serverURL` to override the server URL
+  // (but our server doesn’t need that because it will default
+  // to the client’s domain which is fine in our case)
+  res.json({ isActual: true });
+});
+
 app.get('/mode', (req, res) => {
   res.send(config.mode);
 });

--- a/src/app.js
+++ b/src/app.js
@@ -22,13 +22,6 @@ app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '50mb' }));
 app.use('/sync', syncApp.handlers);
 app.use('/account', accountApp.handlers);
 
-app.get('/client-bootstrap', (req, res) => {
-  // can also return a `serverURL` to override the server URL
-  // (but our server doesn’t need that because it will default
-  // to the client’s domain which is fine in our case)
-  res.json({ isActual: true });
-});
-
 app.get('/mode', (req, res) => {
   res.send(config.mode);
 });


### PR DESCRIPTION
Corresponding PR for https://github.com/actualbudget/actual/pull/649. Also allows specifying relative paths for `webRoot` (such as `../actual/packages/desktop-client/build`, which is useful if you want to test running against a local build of the frontend).