### PR TITLE
🔖 (23.3.1) fix nordigen usage in fly.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-sync",
-  "version": "23.3.0",
+  "version": "23.3.1",
   "license": "MIT",
   "description": "actual syncing server",
   "type": "module",

--- a/src/app-nordigen/services/nordigen-service.js
+++ b/src/app-nordigen/services/nordigen-service.js
@@ -17,8 +17,8 @@ import config from '../../load-config.js';
 
 const NordigenClient = nordigenNode.default;
 const nordigenClient = new NordigenClient({
-  secretId: config.nordigen_secret_id,
-  secretKey: config.nordigen_secret_key,
+  secretId: config.nordigen.secretId,
+  secretKey: config.nordigen.secretKey,
 });
 
 export const handleNordigenError = (response) => {

--- a/src/app-nordigen/services/nordigen-service.js
+++ b/src/app-nordigen/services/nordigen-service.js
@@ -17,8 +17,8 @@ import config from '../../load-config.js';
 
 const NordigenClient = nordigenNode.default;
 const nordigenClient = new NordigenClient({
-  secretId: config.nordigen.secretId,
-  secretKey: config.nordigen.secretKey,
+  secretId: config.nordigen?.secretId,
+  secretKey: config.nordigen?.secretKey,
 });
 
 export const handleNordigenError = (response) => {

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -11,6 +11,8 @@ export interface Config {
     key: string;
     cert: string;
   } & ServerOptions;
-  nordigen_secret_id?: string;
-  nordigen_secret_key?: string;
+  nordigen?: {
+    secretId: string;
+    secretKey: string;
+  };
 }

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -68,10 +68,13 @@ export default {
           ...(config.https || {}),
         }
       : config.https,
-  nordigen: {
-    secretId:
-      process.env.ACTUAL_NORDIGEN_SECRET_ID || config.nordigen?.secretId,
-    secretKey:
-      process.env.ACTUAL_NORDIGEN_SECRET_KEY || config.nordigen?.secretKey,
-  },
+  nordigen:
+    process.env.ACTUAL_NORDIGEN_SECRET_ID &&
+    process.env.ACTUAL_NORDIGEN_SECRET_KEY
+      ? {
+          secretId: process.env.ACTUAL_NORDIGEN_SECRET_ID,
+          secretKey: process.env.ACTUAL_NORDIGEN_SECRET_KEY,
+          ...(config.nordigen || {}),
+        }
+      : config.nordigen,
 };

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -68,4 +68,10 @@ export default {
           ...(config.https || {}),
         }
       : config.https,
+  nordigen: {
+    secretId:
+      process.env.ACTUAL_NORDIGEN_SECRET_ID || config.nordigen?.secretId,
+    secretKey:
+      process.env.ACTUAL_NORDIGEN_SECRET_KEY || config.nordigen?.secretKey,
+  },
 };


### PR DESCRIPTION
This _slightly_ changes the interface for configuring Nordigen, but IMO it's safe to do because

1. the nordigen support is still experimental and subject to breaking changes
2. we released 23.3.0 only an hour ago