### PR TITLE
Don’t make Dockerfile a symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,16 @@
-docker/stable-ubuntu.Dockerfile
+FROM node:16-bullseye as base
+RUN apt-get update && apt-get install -y openssl
+WORKDIR /app
+ADD .yarn ./.yarn
+ADD yarn.lock package.json .yarnrc.yml ./
+RUN yarn workspaces focus --all --production
+
+FROM node:16-bullseye-slim as prod
+RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=base /app/node_modules /app/node_modules
+ADD package.json app.js ./
+ADD src ./src
+ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
+EXPOSE 5006
+CMD ["node", "app.js"]


### PR DESCRIPTION
People have been having issues with this. I copied it from `docker/stable-ubuntu.Dockerfile`. We should follow up on this to remove the duplication at some point but this will help fix the problems people are having now.