### PR TITLE
:bug: (nordigen) close window when opening /nordigen/link path

### DIFF
--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -8,7 +8,6 @@ import {
 } from './errors.js';
 import { handleError } from './util/handle-error.js';
 import validateUser from '../util/validate-user.js';
-import config from '../load-config.js';
 
 const app = express();
 app.get('/link', function (req, res) {

--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import path from 'path';
 
 import { nordigenService } from './services/nordigen-service.js';
 import {
@@ -11,15 +12,7 @@ import validateUser from '../util/validate-user.js';
 
 const app = express();
 app.get('/link', function (req, res) {
-  res.send(`
-<script>window.close();</script>
-
-<p>Please wait...</p>
-<p>
-  The window should close automatically. If nothing happened you can
-  close this window or tab.
-</p>
-`);
+  res.sendFile('link.html', { root: path.resolve('./src/app-nordigen') });
 });
 
 export { app as handlers };

--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -8,8 +8,21 @@ import {
 } from './errors.js';
 import { handleError } from './util/handle-error.js';
 import validateUser from '../util/validate-user.js';
+import config from '../load-config.js';
 
 const app = express();
+app.get('/link', function (req, res) {
+  res.send(`
+<script>window.close();</script>
+
+<p>Please wait...</p>
+<p>
+  The window should close automatically. If nothing happened you can
+  close this window or tab.
+</p>
+`);
+});
+
 export { app as handlers };
 app.use(express.json());
 app.use(async (req, res, next) => {

--- a/src/app-nordigen/link.html
+++ b/src/app-nordigen/link.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Actual</title>
+  </head>
+  <body>
+    <script>
+      window.close();
+    </script>
+
+    <p>Please wait...</p>
+    <p>
+      The window should close automatically. If nothing happened you can close
+      this window or tab.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
When Nordigen accounts are linked 2x windows get opened: 1x (initial tab) is polling for the status; the other window is for authenticating with bank. Once the auth is done - customer is redirected back to app: `/nordigen/link` page. At this point we can just close the tab.

https://github.com/actualbudget/actual/issues/724#issuecomment-1462853590