### PR TITLE
:sparkles: (nordigen) add status endpoint for checking status

### DIFF
--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -25,6 +25,15 @@ app.use(async (req, res, next) => {
   next();
 });
 
+app.post('/status', async (req, res) => {
+  res.send({
+    status: 'ok',
+    data: {
+      configured: nordigenService.isConfigured(),
+    },
+  });
+});
+
 app.post(
   '/create-web-token',
   handleError(async (req, res) => {

--- a/src/app-nordigen/services/nordigen-service.js
+++ b/src/app-nordigen/services/nordigen-service.js
@@ -47,6 +47,14 @@ export const handleNordigenError = (response) => {
 
 export const nordigenService = {
   /**
+   * Check if the Nordigen service is configured to be used.
+   * @returns {boolean}
+   */
+  isConfigured: () => {
+    return !!(nordigenClient.secretId && nordigenClient.secretKey);
+  },
+
+  /**
    *
    * @returns {Promise<void>}
    */


### PR DESCRIPTION
Add a small endpoint that will be used to check the configuration status of Nordigen. If it is not configured - we should not allow people to proceed in the account-link flow.