### PR TITLE
:bug: (nordigen) add currency to account name

### DIFF
--- a/src/app-nordigen/banks/integration-bank.js
+++ b/src/app-nordigen/banks/integration-bank.js
@@ -23,7 +23,9 @@ export default {
       account_id: account.id,
       institution: account.institution,
       mask: (account?.iban || '0000').slice(-4),
-      name: [account.name, printIban(account)].filter(Boolean).join(' '),
+      name: [account.name, printIban(account), account.currency]
+        .filter(Boolean)
+        .join(' '),
       official_name: `integration-${account.institution_id}`,
       type: 'checking',
     };

--- a/src/app-nordigen/banks/tests/integration-bank.spec.js
+++ b/src/app-nordigen/banks/tests/integration-bank.spec.js
@@ -21,7 +21,7 @@ describe('IntegrationBank', () => {
         account_id: account.id,
         institution: mockInstitution,
         mask: '4321',
-        name: 'account-example-one (XXX 4321)',
+        name: 'account-example-one (XXX 4321) PLN',
         official_name: 'integration-SANDBOXFINANCE_SFIN0000',
         type: 'checking',
       });
@@ -36,7 +36,7 @@ describe('IntegrationBank', () => {
         account_id: account.id,
         institution: mockInstitution,
         mask: '0000',
-        name: 'account-example-one',
+        name: 'account-example-one PLN',
         official_name: 'integration-SANDBOXFINANCE_SFIN0000',
         type: 'checking',
       });


### PR DESCRIPTION
Sometimes accounts have the same names and the same IBAN, but different currencies (Paypal).

This should make the account names a bit more unique.. thus easier to distinguish.

https://github.com/actualbudget/actual/issues/724#issuecomment-1464902166

Obviously the user can choose to use different names in `Actual`. They are not forced to use this name.