### PR TITLE
Report parse issues for config.json in default location

### DIFF
--- a/src/load-config.js
+++ b/src/load-config.js
@@ -6,19 +6,24 @@ const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 export const sqlDir = path.join(projectRoot, 'src', 'sql');
 let defaultDataDir = fs.existsSync('/data') ? '/data' : projectRoot;
 
-function parseJSON(path) {
-  return JSON.parse(fs.readFileSync(path, 'utf8'));
+function parseJSON(path, allowMissing = false) {
+  let text;
+  try {
+    text = fs.readFileSync(path, 'utf8');
+  } catch (e) {
+    if (allowMissing) {
+      return {};
+    }
+    throw e;
+  }
+  return JSON.parse(text);
 }
 
 let userConfig;
 if (process.env.ACTUAL_CONFIG_PATH) {
   userConfig = parseJSON(process.env.ACTUAL_CONFIG_PATH);
 } else {
-  try {
-    userConfig = parseJSON(path.join(defaultDataDir, 'config.json'));
-  } catch (e) {
-    // do nothing
-  }
+  userConfig = parseJSON(path.join(defaultDataDir, 'config.json'), true);
 }
 
 /** @type {Omit<import('./config-types.js').Config, 'mode' | 'serverFiles' | 'userFiles'>} */

--- a/upcoming-release-notes/167.md
+++ b/upcoming-release-notes/167.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Jackenmen]
+---
+
+Fix config.json in a default location getting silently ignored when it contains syntax errors.


### PR DESCRIPTION
This changes the behavior of configuration loading when ACTUAL_CONFIG_PATH env var is not specified. With this change, syntax errors in config.json will now be reported if ACTUAL_CONFIG_PATH env var is not specified and the app will not proceed. When the config.json file is not present or cannot be read, the behavior remains the same.