### PR TITLE
:sparkles: (bank-sync) expose demo bank in the get-banks endpoint

### DIFF
--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -88,14 +88,22 @@ app.post(
 app.post(
   '/get-banks',
   handleError(async (req, res) => {
-    let { country } = req.body;
+    let { country, showDemo = false } = req.body;
 
     await nordigenService.setToken();
     const data = await nordigenService.getInstitutions(country);
 
     res.send({
       status: 'ok',
-      data,
+      data: showDemo
+        ? [
+            {
+              id: 'SANDBOXFINANCE_SFIN0000',
+              name: 'DEMO bank (used for testing bank-sync)',
+            },
+            ...data,
+          ]
+        : data,
     });
   }),
 );

--- a/upcoming-release-notes/168.md
+++ b/upcoming-release-notes/168.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Expose demo bank that can be used to test Nordigen bank-sync


### PR DESCRIPTION
Exposing the demo bank again in the get-banks endpoint.

Frontend implementation of the `showDemo` will come next. The demo bank will only be available for DEV and PREVIEW builds. 