### PR TITLE
Include *.test.js files in test run

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -2,7 +2,7 @@
   "setupFiles": ["./jest.setup.js"],
   "testPathIgnorePatterns": ["dist", "/node_modules/", "/build/"],
   "roots": ["<rootDir>"],
-  "testMatch": ["<rootDir>/**/*.spec.js"],
+  "testMatch": ["<rootDir>/**/*.spec.js", "<rootDir>/**/*.test.js"],
   "moduleFileExtensions": ["ts", "js", "json"],
   "testEnvironment": "node",
   "collectCoverage": true,


### PR DESCRIPTION
When working on something else, I noticed that `.test.js` files were not running due to `jest.config.json` not including them. I went ahead and re-enabled these tests to make sure that unit tests are actually being run.

There are 2 alternative solutions:
1. Removing `testMatch` option altogether as it isn't really any better from the default value which also makes sure that tests written in TypeScript will work if this project ever migrates to using it fully (https://jestjs.io/docs/configuration#testmatch-arraystring)
    - I think this is actually a superior solution to the one currently here
3. Renaming `app-sync.test.js` file to `app-sync.spec.js` file as it's the only file that doesn't match the current config.