### PR TITLE
Stream file without loading to memory in /download-user-file

### DIFF
--- a/src/app-sync.js
+++ b/src/app-sync.js
@@ -291,7 +291,7 @@ app.post('/upload-user-file', async (req, res) => {
   }
 });
 
-app.get('/download-user-file', async (req, res) => {
+app.get('/download-user-file', async (req, res, next) => {
   let user = validateUser(req, res);
   if (!user) {
     return;
@@ -313,17 +313,17 @@ app.get('/download-user-file', async (req, res) => {
     return;
   }
 
-  let buffer;
-  try {
-    buffer = await fs.readFile(getPathForUserFile(fileId));
-  } catch (e) {
-    console.log(`Error: file does not exist: ${getPathForUserFile(fileId)}`);
-    res.status(500).send('File does not exist on server');
-    return;
-  }
-
   res.setHeader('Content-Disposition', `attachment;filename=${fileId}`);
-  res.send(buffer);
+  res.sendFile(getPathForUserFile(fileId), function (err) {
+    if (err) {
+      if (err.status == 404) {
+        console.log('File does not exist on server.');
+        res.status(500).send('File does not exist on server.');
+      } else {
+        next(err);
+      }
+    }
+  });
 });
 
 app.post('/update-user-filename', (req, res) => {

--- a/src/app-sync.js
+++ b/src/app-sync.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import express from 'express';
-import { HttpError } from 'http-errors';
 import * as uuid from 'uuid';
 import validateUser from './util/validate-user.js';
 import errorMiddleware from './util/error-middleware.js';
@@ -292,7 +291,7 @@ app.post('/upload-user-file', async (req, res) => {
   }
 });
 
-app.get('/download-user-file', async (req, res, next) => {
+app.get('/download-user-file', async (req, res) => {
   let user = validateUser(req, res);
   if (!user) {
     return;
@@ -315,16 +314,7 @@ app.get('/download-user-file', async (req, res, next) => {
   }
 
   res.setHeader('Content-Disposition', `attachment;filename=${fileId}`);
-  res.sendFile(getPathForUserFile(fileId), function (err) {
-    if (err) {
-      if (err instanceof HttpError && err.status == 404) {
-        console.log('File does not exist on server.');
-        res.status(500).send('File does not exist on server.');
-      } else {
-        next(err);
-      }
-    }
-  });
+  res.sendFile(getPathForUserFile(fileId));
 });
 
 app.post('/update-user-filename', (req, res) => {

--- a/src/app-sync.js
+++ b/src/app-sync.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import express from 'express';
+import { HttpError } from 'http-errors';
 import * as uuid from 'uuid';
 import validateUser from './util/validate-user.js';
 import errorMiddleware from './util/error-middleware.js';
@@ -316,7 +317,7 @@ app.get('/download-user-file', async (req, res, next) => {
   res.setHeader('Content-Disposition', `attachment;filename=${fileId}`);
   res.sendFile(getPathForUserFile(fileId), function (err) {
     if (err) {
-      if (err.status == 404) {
+      if (err instanceof HttpError && err.status == 404) {
         console.log('File does not exist on server.');
         res.status(500).send('File does not exist on server.');
       } else {

--- a/src/app-sync.test.js
+++ b/src/app-sync.test.js
@@ -50,7 +50,7 @@ describe('/download-user-file', () => {
         .set('x-actual-token', 'valid-token')
         .set('x-actual-file-id', 'missing-fs-file');
 
-      expect(res.statusCode).toEqual(500);
+      expect(res.statusCode).toEqual(404);
     });
 
     it('returns an attachment file', async () => {

--- a/upcoming-release-notes/172.md
+++ b/upcoming-release-notes/172.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Jackenmen]
+---
+
+Changed budget file download endpoint to use less memory by using streams


### PR DESCRIPTION
Briefly mentioned by @j-f1 here: https://discord.com/channels/937901803608096828/940290142579605514/1089653624390561822

I opted to keep the `500` HTTP code as is and therefore had to add a callback to `res.sendFile()` call and use a different code. I can instead update the test to check for `404` and remove the callback entirely.

This could be extended to `/upload-user-file` by removing the `application/actual-sync` and `application/encrypted-file` middleware and just use `req` as a stream by piping it into a file (with some added check for `Content-Length` header to ensure that we still have some max size for these files)