### PR TITLE
Add support for armv6l (alpine based images)

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -37,10 +37,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, alpine]
-        platform: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6]
+        arch: [amd64, arm64, arm/v7, arm/v6]
         exclude:
           - os: ubuntu
-            platform: linux/arm/v6
+            arch: arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -80,7 +80,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           file: docker/edge-${{ matrix.os }}.Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -37,6 +37,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, alpine]
+        platform: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6]
+        exclude:
+          - os: ubuntu
+            platform: linux/arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -76,7 +80,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           file: docker/edge-${{ matrix.os }}.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -76,7 +76,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           file: docker/edge-${{ matrix.os }}.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -85,5 +85,5 @@ jobs:
           context: .
           push: true
           file: docker/stable-alpine.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.alpine-meta.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,6 +27,13 @@ jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu, alpine]
+        platform: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6]
+        exclude:
+          - os: ubuntu
+            platform: linux/arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -70,20 +77,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push standard image
+      - name: Build and push image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          file: docker/stable-ubuntu.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          file: docker/stable-${{ matrix.os }}.Dockerfile
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
-
-      - name: Build and push Alpine image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          file: docker/stable-alpine.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-          tags: ${{ steps.alpine-meta.outputs.tags }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,10 +30,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, alpine]
-        platform: [linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6]
+        arch: [amd64, arm64, arm/v7, arm/v6]
         exclude:
           - os: ubuntu
-            platform: linux/arm/v6
+            arch: arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -83,5 +83,5 @@ jobs:
           context: .
           push: true
           file: docker/stable-${{ matrix.os }}.Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/${{ matrix.arch }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker/edge-alpine.Dockerfile
+++ b/docker/edge-alpine.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 ADD .yarn ./.yarn
 ADD yarn.lock package.json .yarnrc.yml ./
 RUN yarn workspaces focus --all --production
+RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --build-from-source; fi
 
 RUN mkdir /public
 ADD "https://api.github.com/repos/actualbudget/actual/actions/artifacts?name=actual-web&per_page=100" /tmp/artifacts.json

--- a/docker/stable-alpine.Dockerfile
+++ b/docker/stable-alpine.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 ADD .yarn ./.yarn
 ADD yarn.lock package.json .yarnrc.yml ./
 RUN yarn workspaces focus --all --production
+RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --build-from-source; fi
 
 FROM alpine:3.17 as prod
 RUN apk add --no-cache nodejs tini

--- a/upcoming-release-notes/182.md
+++ b/upcoming-release-notes/182.md
@@ -3,4 +3,4 @@ category: Features
 authors: [intiplink]
 ---
 
-Add support for armv6l (alpine based images)
+Add support for armv6l (Alpine-based images only)

--- a/upcoming-release-notes/182.md
+++ b/upcoming-release-notes/182.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [intiplink]
+---
+
+Add support for armv6l (alpine based images)


### PR DESCRIPTION
GitHub CI log:
```
[linux/arm/v6 base 6/8] RUN yarn workspaces focus --all --production
204.6 ➤ YN0007: │ bcrypt@npm:5.1.0 must be built because it never has been before or the last one failed
204.6 ➤ YN0007: │ better-sqlite3@npm:8.2.0 must be built because it never has been before or the last one failed
...
[linux/arm/v7 base 6/8] RUN yarn workspaces focus --all --production
203.8 ➤ YN0007: │ bcrypt@npm:5.1.0 must be built because it never has been before or the last one failed
203.8 ➤ YN0007: │ better-sqlite3@npm:8.2.0 must be built because it never has been before or the last one failed
```

It seems that both armv6 and armv7 have the same issues with `bcrypt` and `better-sqlite3` not being built. These packages are required to build from source, luckily QEMU use armv7l for compiling.

Tested and working on RPi Zero W.

