### PR TITLE
github action workflow: revert old way to build images

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -38,10 +38,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, alpine]
-        arch: [amd64, arm64, arm/v7, arm/v6]
-        exclude:
-          - os: ubuntu
-            arch: arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -81,7 +77,7 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           file: docker/edge-${{ matrix.os }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7${{ matrix.os == 'alpine' && ',linux/arm/v6' || '' }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,13 +27,6 @@ jobs:
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu, alpine]
-        arch: [amd64, arm64, arm/v7, arm/v6]
-        exclude:
-          - os: ubuntu
-            arch: arm/v6
     steps:
       - uses: actions/checkout@v3
 
@@ -77,11 +70,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build and push ubuntu image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          file: docker/stable-${{ matrix.os }}.Dockerfile
-          platforms: linux/${{ matrix.arch }}
+          file: docker/stable-ubuntu.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Build and push alpine image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          file: docker/stable-alpine.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          tags: ${{ steps.alpine-meta.outputs.tags }}


### PR DESCRIPTION
Honestly, I am not sure why the parallel build failed, even though parallel build succeed on `edge` with 2 threads. I hope someone more knowledgeable can contribute a better github action workflow