### PR TITLE
Add `express-rate-limit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "debug": "^4.3.4",
     "express": "4.18.2",
     "express-actuator": "1.8.4",
+    "express-rate-limit": "^6.7.0",
     "express-response-size": "^0.0.3",
     "jws": "^4.0.0",
     "nordigen-node": "^1.2.3",

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import actuator from 'express-actuator';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import config from './load-config.js';
+import rateLimit from 'express-rate-limit';
 
 import * as accountApp from './app-account.js';
 import * as syncApp from './app-sync.js';
@@ -16,6 +17,14 @@ process.on('unhandledRejection', (reason) => {
 });
 
 app.use(cors());
+app.use(
+  rateLimit({
+    windowMs: 60 * 1000,
+    max: 500,
+    legacyHeaders: false,
+    standardHeaders: true,
+  }),
+);
 app.use(bodyParser.json({ limit: '20mb' }));
 app.use(bodyParser.raw({ type: 'application/actual-sync', limit: '20mb' }));
 app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '50mb' }));

--- a/upcoming-release-notes/187.md
+++ b/upcoming-release-notes/187.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [j-f1]
 ---
 

--- a/upcoming-release-notes/187.md
+++ b/upcoming-release-notes/187.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [j-f1]
+---
+
+Add rate limiting to all server requests

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,6 +1578,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     express: 4.18.2
     express-actuator: 1.8.4
+    express-rate-limit: ^6.7.0
     express-response-size: ^0.0.3
     jest: ^29.3.1
     jws: ^4.0.0
@@ -2807,6 +2808,15 @@ __metadata:
     dayjs: ^1.11.3
     properties-reader: ^2.2.0
   checksum: c0b4b4f7d046d4209ffe60face333e76abd9d627905a5700b9a67d6966cf499ab47d2c4c0d095bdcbedbdc82e5b791879600074cc63b94d7d8fcbdb8a71fe95e
+  languageName: node
+  linkType: hard
+
+"express-rate-limit@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "express-rate-limit@npm:6.7.0"
+  peerDependencies:
+    express: ^4 || ^5
+  checksum: 7bd3f298b202cdb11c3d7c2dcff9be12c6885be5e64fb112f6c79103ba93a8e5d899ce15a5a3ce48f82190ab3515bed403e067dc3e42fc2832558cbe2620f955
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
CodeQL keeps yelling at us about this… I’m not sure if the filter is smart enough to use this rate limit middleware to remove the warnings, but at least we will be setting a reasonable bound on attempts to crack the server password.