### PR TITLE
Add a handler for AxiosError errors

### DIFF
--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -1,6 +1,7 @@
 import { isAxiosError } from 'axios';
 import express from 'express';
 import path from 'path';
+import { inspect } from 'util';
 
 import { nordigenService } from './services/nordigen-service.js';
 import {
@@ -194,24 +195,24 @@ app.post(
           });
           break;
         case error instanceof GenericNordigenError:
-          console.log({ message: 'Something went wrong', error });
+          console.log('Something went wrong', inspect(error, { depth: null }));
           sendErrorResponse({
             error_type: 'SYNC_ERROR',
             error_code: 'NORDIGEN_ERROR',
           });
           break;
         case isAxiosError(error):
-          console.log({
-            message: 'Something went wrong',
-            error: error.response.data,
-          });
+          console.log(
+            'Something went wrong',
+            inspect(error.response.data, { depth: null }),
+          );
           sendErrorResponse({
             error_type: 'SYNC_ERROR',
             error_code: 'NORDIGEN_ERROR',
           });
           break;
         default:
-          console.log({ message: 'Something went wrong', error });
+          console.log('Something went wrong', inspect(error, { depth: null }));
           sendErrorResponse({
             error_type: 'UNKNOWN',
             error_code: 'UNKNOWN',

--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios';
 import express from 'express';
 import path from 'path';
 
@@ -194,6 +195,16 @@ app.post(
           break;
         case error instanceof GenericNordigenError:
           console.log({ message: 'Something went wrong', error });
+          sendErrorResponse({
+            error_type: 'SYNC_ERROR',
+            error_code: 'NORDIGEN_ERROR',
+          });
+          break;
+        case isAxiosError(error):
+          console.log({
+            message: 'Something went wrong',
+            error: error.response.data,
+          });
           sendErrorResponse({
             error_type: 'SYNC_ERROR',
             error_code: 'NORDIGEN_ERROR',

--- a/upcoming-release-notes/189.md
+++ b/upcoming-release-notes/189.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [j-f1]
+---
+
+More clearly report the problem with Nordigen requests that fail with an unexpected status code


### PR DESCRIPTION
This will help debug more clearly when Nordigen’s API returns unexpected status codes, since the current shape causes the actual response data to be collapsed in the console logs.