### PR TITLE
Add a field with all transactions to /nordigen/transactions endpoint

### DIFF
--- a/src/app-nordigen/app-nordigen.js
+++ b/src/app-nordigen/app-nordigen.js
@@ -149,7 +149,7 @@ app.post(
         balances,
         institutionId,
         startingBalance,
-        transactions: { booked, pending },
+        transactions: { booked, pending, all },
       } = await nordigenService.getTransactionsWithBalance(
         requisitionId,
         accountId,
@@ -167,6 +167,7 @@ app.post(
           transactions: {
             booked,
             pending,
+            all,
           },
         },
       });

--- a/src/app-nordigen/banks/bank.interface.ts
+++ b/src/app-nordigen/banks/bank.interface.ts
@@ -16,7 +16,7 @@ export interface IBank {
   /**
    * Function sorts an array of transactions from newest to oldest
    */
-  sortTransactions: (transactions: Transaction[]) => Transaction[];
+  sortTransactions: <T extends Transaction>(transactions: T[]) => T[];
 
   /**
    * Calculates account balance before which was before transactions provided in sortedTransactions param

--- a/src/app-nordigen/nordigen.types.ts
+++ b/src/app-nordigen/nordigen.types.ts
@@ -4,6 +4,7 @@ import {
   Institution,
   Transactions,
   Balance,
+  Transaction,
 } from './nordigen-node.types.js';
 
 export type DetailedAccount = Omit<NordigenAccountDetails, 'status'> &
@@ -11,6 +12,7 @@ export type DetailedAccount = Omit<NordigenAccountDetails, 'status'> &
 export type DetailedAccountWithInstitution = DetailedAccount & {
   institution: Institution;
 };
+export type TransactionWithBookedStatus = Transaction & { booked: boolean };
 
 export type NormalizedAccountDetails = {
   /**

--- a/src/app-nordigen/services/nordigen-service.js
+++ b/src/app-nordigen/services/nordigen-service.js
@@ -170,7 +170,7 @@ export const nordigenService = {
    * @throws {RateLimitError}
    * @throws {UnknownError}
    * @throws {ServiceError}
-   * @returns {Promise<{iban: string, balances: Array<import('../nordigen-node.types.js').Balance>, institutionId: string, transactions: {booked: Array<import('../nordigen-node.types.js').Transaction>, pending: Array<import('../nordigen-node.types.js').Transaction>}, startingBalance: number}>}
+   * @returns {Promise<{iban: string, balances: Array<import('../nordigen-node.types.js').Balance>, institutionId: string, transactions: {booked: Array<import('../nordigen-node.types.js').Transaction>, pending: Array<import('../nordigen-node.types.js').Transaction>, all: Array<import('../nordigen.types.js').TransactionWithBookedStatus>}, startingBalance: number}>}
    */
   getTransactionsWithBalance: async (
     requisitionId,
@@ -202,6 +202,13 @@ export const nordigenService = {
     const sortedPendingTransactions = bank.sortTransactions(
       transactions.transactions?.pending,
     );
+    const allTransactions = sortedBookedTransactions.map((t) => {
+      return { ...t, booked: true };
+    });
+    sortedPendingTransactions.forEach((t) =>
+      allTransactions.push({ ...t, booked: false }),
+    );
+    const sortedAllTransactions = bank.sortTransactions(allTransactions);
 
     const startingBalance = bank.calculateStartingBalance(
       sortedBookedTransactions,
@@ -216,6 +223,7 @@ export const nordigenService = {
       transactions: {
         booked: sortedBookedTransactions,
         pending: sortedPendingTransactions,
+        all: sortedAllTransactions,
       },
     };
   },

--- a/src/app-nordigen/services/tests/nordigen-service.spec.js
+++ b/src/app-nordigen/services/tests/nordigen-service.spec.js
@@ -173,6 +173,24 @@ describe('nordigenService', () => {
           institutionId: mockRequisition.institution_id,
           startingBalance: expect.any(Number),
           transactions: {
+            all: expect.arrayContaining([
+              expect.objectContaining({
+                bookingDate: expect.any(String),
+                transactionAmount: {
+                  amount: expect.any(String),
+                  currency: 'EUR',
+                },
+                transactionId: expect.any(String),
+                valueDate: expect.any(String),
+              }),
+              expect.objectContaining({
+                transactionAmount: {
+                  amount: expect.any(String),
+                  currency: 'EUR',
+                },
+                valueDate: expect.any(String),
+              }),
+            ]),
             booked: expect.arrayContaining([
               expect.objectContaining({
                 bookingDate: expect.any(String),

--- a/upcoming-release-notes/190.md
+++ b/upcoming-release-notes/190.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Jackenmen]
+---
+
+Add an `all` field to /nordigen/transactions endpoint with ordered array of both booked and pending transactions


### PR DESCRIPTION
Helps with actualbudget/actual#919 by adding the `all` field wit both pending and booked transactions to the output of `getTransactionsWithBalance()` and, by extension, the `/nordigen/transactions` endpoint.

I could alter the `getTransactions()` to return the `all` field as well but I figured that keeping it such that it returns the output from Nordigen API 1:1 might be better so I left it as is. If you don't agree, let me know and I'll update this.