### PR TITLE
Authenticate request for artifacts

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -71,6 +71,11 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download artifacts
+        run: ./docker/download-artifacts.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push image
         uses: docker/build-push-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 *.crt
 *.pem
 *.key
+artifacts.json
 
 # Yarn
 .pnp.*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -p 5006:5006 actual-server
 
 The multi-arch Docker container image runs on amd64, arm64, and armv7 platforms. Please be warned that Actual may be sluggish on armv7, but users report that it does work.
 
-Note: if you would like to build the edge image variant locally, make sure you run `./docker/download-artifacts.sh` first.
+Note: if you would like to build the edge image variant locally, make sure you run `./docker/download-artifacts.sh` first. Then run `docker build . -f docker/edge-ubuntu.Dockerfile --build-arg GITHUB_TOKEN="ghp_your-personal-access-token"`.
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ docker run -p 5006:5006 actual-server
 
 The multi-arch Docker container image runs on amd64, arm64, and armv7 platforms. Please be warned that Actual may be sluggish on armv7, but users report that it does work.
 
+Note: if you would like to build the edge image variant locally, make sure you run `./docker/download-artifacts.sh` first.
+
 ## Deploying
 
 You should deploy your server so it's always running. We recommend [fly.io](https://fly.io) which makes it incredibly easy and provides a free plan.

--- a/docker/download-artifacts.sh
+++ b/docker/download-artifacts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+URL="https://api.github.com/repos/actualbudget/actual/actions/artifacts?name=actual-web&per_page=100"
+
+if [ -n "$GITHUB_TOKEN" ]; then
+  curl -L -o artifacts.json --header "Authorization: Bearer ${GITHUB_TOKEN}" $URL
+else
+  curl -L -o artifacts.json $URL
+fi
+
+if [ $? -ne 0 ]; then
+  echo "Failed to download artifacts.json"
+  exit 1
+fi

--- a/docker/edge-alpine.Dockerfile
+++ b/docker/edge-alpine.Dockerfile
@@ -7,7 +7,7 @@ RUN yarn workspaces focus --all --production
 RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --build-from-source; fi
 
 RUN mkdir /public
-ADD "https://api.github.com/repos/actualbudget/actual/actions/artifacts?name=actual-web&per_page=100" /tmp/artifacts.json
+ADD artifacts.json /tmp/artifacts.json
 RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master")][0]' /tmp/artifacts.json > /tmp/latest-build.json
 
 ARG GITHUB_TOKEN

--- a/docker/edge-ubuntu.Dockerfile
+++ b/docker/edge-ubuntu.Dockerfile
@@ -6,7 +6,7 @@ ADD yarn.lock package.json .yarnrc.yml ./
 RUN yarn workspaces focus --all --production
 
 RUN mkdir /public
-ADD "https://api.github.com/repos/actualbudget/actual/actions/artifacts?name=actual-web&per_page=100" /tmp/artifacts.json
+ADD artifacts.json /tmp/artifacts.json
 RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master")][0]' /tmp/artifacts.json > /tmp/latest-build.json
 
 ARG GITHUB_TOKEN

--- a/upcoming-release-notes/204.md
+++ b/upcoming-release-notes/204.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Fix build process for edge Docker images


### PR DESCRIPTION
Previously, the latest artifact list was requested unauthenticated using `ADD "https://api.github.com/..." /tmp/artifacts.json`. While this works locally, on GitHub’s servers it seems that the per-IP rate limit was exceeded. There isn’t a way to get Docker to pass the `Authorization` header that I know of, so this work has been moved to an external shell script that pulls down the relevant data.