### PR TITLE
Add a health check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "NODE_ENV=test NODE_OPTIONS='--experimental-vm-modules --trace-warnings' jest  --coverage",
     "types": "tsc --noEmit --incremental",
     "verify": "yarn -s lint && yarn types",
-    "reset-password": "node src/scripts/reset-password.js"
+    "reset-password": "node src/scripts/reset-password.js",
+    "health-check": "node src/scripts/health-check.js"
   },
   "dependencies": {
     "@actual-app/api": "6.1.0",

--- a/src/scripts/health-check.js
+++ b/src/scripts/health-check.js
@@ -1,0 +1,20 @@
+import fetch from 'node-fetch';
+import config from '../load-config.js';
+
+let protocol = config.https ? 'https' : 'http';
+let hostname = config.hostname === '::' ? 'localhost' : config.hostname;
+
+fetch(`${protocol}://${hostname}:${config.port}/health`)
+  .then((res) => res.json())
+  .then((res) => {
+    if (res.status !== 'UP') {
+      throw new Error(
+        'Health check failed: Server responded to health check with status ' +
+          res.status,
+      );
+    }
+  })
+  .catch((err) => {
+    console.log('Health check failed:', err);
+    process.exit(1);
+  });

--- a/upcoming-release-notes/214.md
+++ b/upcoming-release-notes/214.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [j-f1]
+---
+
+Add a health check script (useful if running inside of a Docker container)


### PR DESCRIPTION
This allows running a health check from inside the container. Usage: `npm run health-check`. That may not work inside of Alpine containers, so you can do `node src/scripts/health-check.js` directly instead. Fixes #213.