### PR TITLE
⬆️ (nordigen-node) upgrade to v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express-rate-limit": "^6.7.0",
     "express-response-size": "^0.0.3",
     "jws": "^4.0.0",
-    "nordigen-node": "^1.2.3",
+    "nordigen-node": "^1.2.6",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -33,6 +33,7 @@ app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '50mb' }));
 app.use('/sync', syncApp.handlers);
 app.use('/account', accountApp.handlers);
 app.use('/nordigen', nordigenApp.handlers);
+app.use('/gocardless', nordigenApp.handlers);
 app.use('/secret', secretApp.handlers);
 
 app.get('/mode', (req, res) => {

--- a/upcoming-release-notes/229.md
+++ b/upcoming-release-notes/229.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Upgrade `nordigen-node` to v1.2.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,7 +1582,7 @@ __metadata:
     express-response-size: ^0.0.3
     jest: ^29.3.1
     jws: ^4.0.0
-    nordigen-node: ^1.2.3
+    nordigen-node: ^1.2.6
     prettier: ^2.8.3
     supertest: ^6.3.1
     typescript: ^4.9.5
@@ -4703,13 +4703,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nordigen-node@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "nordigen-node@npm:1.2.3"
+"nordigen-node@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "nordigen-node@npm:1.2.6"
   dependencies:
     axios: ^1.2.1
     dotenv: ^10.0.0
-  checksum: 721b1b87e750ddde72e97de6b77791da71b0f7206397b485ceb8c271121d26d0e76613b95896b762f9b88eb32fd9cf83202c638a3aeade956910c6971639146b
+  checksum: 04f26def5f743abff3897448c3a65b91301787fe995d72f420cccf0a91dd44cd750453099cace51eb8fa474aecbf4b553955cbe8c9ed9c680a678c59d8685737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. upgrade `nordigen-node` to 1.2.6 (which uses the new gocardless domain)
2. allow accessing `nordigen` functionality via `/gocardless` to unblock using the new API path in actual-web