### PR TITLE
:fire: (nordigen) removing env var/config file support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt
-      # - ACTUAL_NORDIGEN_SECRET_ID=xxxx
-      # - ACTUAL_NORDIGEN_SECRET_KEY=xxxx
       # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration
       # !! If you are not using any of these options, remove the 'environment:' tag entirely.
     volumes:

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -11,8 +11,4 @@ export interface Config {
     key: string;
     cert: string;
   } & ServerOptions;
-  nordigen?: {
-    secretId: string;
-    secretKey: string;
-  };
 }

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -85,15 +85,6 @@ const finalConfig = {
           ...(config.https || {}),
         }
       : config.https,
-  nordigen:
-    process.env.ACTUAL_NORDIGEN_SECRET_ID &&
-    process.env.ACTUAL_NORDIGEN_SECRET_KEY
-      ? {
-          secretId: process.env.ACTUAL_NORDIGEN_SECRET_ID,
-          secretKey: process.env.ACTUAL_NORDIGEN_SECRET_KEY,
-          ...(config.nordigen || {}),
-        }
-      : config.nordigen,
 };
 
 debug(`using port ${finalConfig.port}`);
@@ -107,21 +98,6 @@ if (finalConfig.https) {
   debugSensitive(`using https key ${finalConfig.https.key}`);
   debug(`using https cert: ${'*'.repeat(finalConfig.https.cert.length)}`);
   debugSensitive(`using https cert ${finalConfig.https.cert}`);
-}
-
-if (finalConfig.nordigen) {
-  debug(
-    `using nordigen secret id: ${'*'.repeat(
-      finalConfig.nordigen.secretId.length,
-    )}`,
-  );
-  debugSensitive(`using nordigen secret id ${finalConfig.nordigen.secretId}`);
-  debug(
-    `using nordigen secret key: ${'*'.repeat(
-      finalConfig.nordigen.secretKey.length,
-    )}`,
-  );
-  debugSensitive(`using nordigen secret key ${finalConfig.nordigen.secretKey}`);
 }
 
 export default finalConfig;

--- a/src/services/secrets-service.js
+++ b/src/services/secrets-service.js
@@ -1,6 +1,6 @@
 import createDebug from 'debug';
 import fs from 'node:fs';
-import config, { sqlDir } from '../load-config.js';
+import { sqlDir } from '../load-config.js';
 import { join } from 'node:path';
 import getAccountDb from '../account-db.js';
 

--- a/src/services/secrets-service.js
+++ b/src/services/secrets-service.js
@@ -19,22 +19,6 @@ class SecretsDb {
     this.debug = createDebug('actual:secrets-db');
     this.db = null;
     this.initialize();
-    this.migrateGoCardless();
-  }
-
-  /// Migrates GoCardless from config.json or process.env to app secret
-  migrateGoCardless() {
-    if (
-      config.nordigen &&
-      (!this.get(SecretName.nordigen_secretId) ||
-        !this.get(SecretName.nordigen_secretKey))
-    ) {
-      this.set(SecretName.nordigen_secretId, config.nordigen.secretId);
-      this.set(SecretName.nordigen_secretKey, config.nordigen.secretKey);
-      this.debug(
-        'Migrated Nordigen keys from config.json/environment to app secrets',
-      );
-    }
   }
 
   initialize() {

--- a/upcoming-release-notes/235.md
+++ b/upcoming-release-notes/235.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove legacy env var/config file usage for nordigen secrets


### PR DESCRIPTION
Removing env var/config file support for Nordigen secrets. These have been migrated to the new `secrets` db table a while ago. We can now clean up the legacy implementation for these secrets.