### PR TITLE
Add NORWEGIAN-XX-NORWNOK1 GoCardless integration

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -2,6 +2,7 @@ import AmericanExpressAesudef1 from './banks/american-express-aesudef1.js';
 import IngPlIngbplpw from './banks/ing-pl-ingbplpw.js';
 import IntegrationBank from './banks/integration-bank.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
+import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
 
 const banks = [
@@ -9,6 +10,7 @@ const banks = [
   IngPlIngbplpw,
   MbankRetailBrexplpw,
   SandboxfinanceSfin0000,
+  NorwegianXxNorwnok1,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/banks/american-express-aesudef1.js
+++ b/src/app-gocardless/banks/american-express-aesudef1.js
@@ -1,4 +1,4 @@
-import { amountToInteger, sortByBookingDate } from '../utils.js';
+import { amountToInteger, sortByBookingDateOrValueDate } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -32,7 +32,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDate(transactions);
+    return sortByBookingDateOrValueDate(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/integration-bank.js
+++ b/src/app-gocardless/banks/integration-bank.js
@@ -1,4 +1,8 @@
-import { sortByBookingDate, amountToInteger, printIban } from '../utils.js';
+import {
+  sortByBookingDateOrValueDate,
+  amountToInteger,
+  printIban,
+} from '../utils.js';
 
 const SORTED_BALANCE_TYPE_LIST = [
   'closingBooked',
@@ -41,7 +45,7 @@ export default {
       'Available (first 10) transactions properties for new integration of institution in sortTransactions function',
       { top10Transactions: JSON.stringify(transactions.slice(0, 10)) },
     );
-    return sortByBookingDate(transactions);
+    return sortByBookingDateOrValueDate(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {

--- a/src/app-gocardless/banks/norwegian-xx-norwnok1.js
+++ b/src/app-gocardless/banks/norwegian-xx-norwnok1.js
@@ -1,0 +1,100 @@
+import {
+  printIban,
+  amountToInteger,
+  sortByBookingDateOrValueDate,
+} from '../utils.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  institutionIds: [
+    'NORWEGIAN_NO_NORWNOK1',
+    'NORWEGIAN_SE_NORWNOK1',
+    'NORWEGIAN_DE_NORWNOK1',
+    'NORWEGIAN_DK_NORWNOK1',
+    'NORWEGIAN_ES_NORWNOK1',
+    'NORWEGIAN_FI_NORWNOK1',
+  ],
+
+  normalizeAccount(account) {
+    return {
+      account_id: account.id,
+      institution: account.institution,
+      mask: account.iban.slice(-4),
+      iban: account.iban,
+      name: [account.name, printIban(account)].join(' '),
+      official_name: account.product,
+      type: 'checking',
+    };
+  },
+
+  normalizeTransaction(transaction, booked) {
+    /**
+     * The way Bank Norwegian handles the date fields is rather strange and
+     * countrary to GoCardless's documentation.
+     *
+     * For booked transactions Bank Norwegian sends a `valueDate` field that
+     * doesn't match the NextGenPSD2 definition of `valueDate` which is what we
+     * expect to receive from GoCardless.  Therefore we remove the incorrect
+     * field so that transactions are correctly imported.
+     */
+    if (booked) {
+      delete transaction.valueDate;
+      return transaction;
+    }
+
+    /**
+     * For pending transactions there are two possibilities.  Either the
+     * transaction has a `valueDate`, in which case the `valueDate` we receive
+     * corresponds to when the transaction actually occurred, and so we simply
+     * return the transaction as-is.
+     */
+    if (transaction.valueDate !== undefined) {
+      return transaction;
+    }
+
+    /**
+     * If the pending transaction didn't have a `valueDate` field then it
+     * should have a `remittanceInformationStructured` field which contains the
+     * date we expect to receive as the `valueDate`.  In this case we extract
+     * the date from that field and set it as `valueDate`.
+     */
+    if (transaction.remittanceInformationStructured) {
+      const remittanceInfoRegex = / (\d{4}-\d{2}-\d{2}) /;
+      const matches =
+        transaction.remittanceInformationStructured.match(remittanceInfoRegex);
+      if (matches) {
+        transaction.valueDate = matches[1];
+        return transaction;
+      }
+    }
+
+    /**
+     * If neither pending case is true we return `null` and ignore the
+     * transaction until it's been further processed by the bank.
+     */
+    return null;
+  },
+
+  sortTransactions(transactions = []) {
+    return sortByBookingDateOrValueDate(transactions);
+  },
+
+  /**
+   *  For NORWEGIAN_XX_NORWNOK1 we don't know what balance was
+   *  after each transaction so we have to calculate it by getting
+   *  current balance from the account and subtract all the transactions
+   *
+   *  As a current balance we use `expected` balance type because it
+   *  corresponds to the current running balance, whereas `interimAvailable`
+   *  holds the remaining credit limit.
+   */
+  calculateStartingBalance(sortedTransactions = [], balances = []) {
+    const currentBalance = balances.find(
+      (balance) => 'expected' === balance.balanceType,
+    );
+
+    return sortedTransactions.reduce((total, trans) => {
+      return total - amountToInteger(trans.transactionAmount.amount);
+    }, amountToInteger(currentBalance.balanceAmount.amount));
+  },
+};

--- a/src/app-gocardless/gocardless-node.types.ts
+++ b/src/app-gocardless/gocardless-node.types.ts
@@ -433,7 +433,7 @@ export type Transaction = {
   /**
    * Reference as contained in the structured remittance reference structure
    */
-  remittanceInformation?: string;
+  remittanceInformationStructured?: string;
 
   /**
    * The amount of the transaction as billed to the account

--- a/src/app-gocardless/tests/utils.spec.js
+++ b/src/app-gocardless/tests/utils.spec.js
@@ -1,5 +1,5 @@
 import { mockTransactionAmount } from '../services/tests/fixtures.js';
-import { sortByBookingDate } from '../utils.js';
+import { sortByBookingDateOrValueDate } from '../utils.js';
 
 describe('utils', () => {
   describe('#sortByBookingDate', () => {
@@ -18,7 +18,7 @@ describe('utils', () => {
           transactionAmount: mockTransactionAmount,
         },
       ];
-      expect(sortByBookingDate(transactions)).toEqual([
+      expect(sortByBookingDateOrValueDate(transactions)).toEqual([
         {
           bookingDate: '2023-01-20',
           transactionAmount: mockTransactionAmount,

--- a/src/app-gocardless/utils.js
+++ b/src/app-gocardless/utils.js
@@ -6,9 +6,11 @@ export const printIban = (account) => {
   }
 };
 
-export const sortByBookingDate = (transactions = []) =>
+export const sortByBookingDateOrValueDate = (transactions = []) =>
   transactions.sort(
-    (a, b) => +new Date(b.bookingDate) - +new Date(a.bookingDate),
+    (a, b) =>
+      +new Date(b.bookingDate || b.valueDate) -
+      +new Date(a.bookingDate || a.valueDate),
   );
 
 export const amountToInteger = (n) => Math.round(n * 100);

--- a/upcoming-release-notes/237.md
+++ b/upcoming-release-notes/237.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Add all integration for all Bank Norwegian branches to the GoCardless support.


### PR DESCRIPTION
This adds explicit support for all branchs of Bank Norwegian to the GoCardless integration to work around the issue reported in actualbudget/actual#1392 where their use of `valueDate` does not match the NextGenPSD2 definition which is what we expect to receive from GoCardless.  To work around this we simply remove this field when normalizing transactions and let the Actual app use `bookingDate` instead.

Resolves actualbudget/actual#1392.