### PR TITLE
Make endDate optional when downloading GoCardless transactions

### DIFF
--- a/src/app-gocardless/gocardless.types.ts
+++ b/src/app-gocardless/gocardless.types.ts
@@ -65,7 +65,7 @@ export type GetTransactionsParams = {
   /**
    * End date of the period from which we want to download transactions
    */
-  endDate: string;
+  endDate?: string;
 };
 
 export type GetTransactionsResponse = {

--- a/upcoming-release-notes/241.md
+++ b/upcoming-release-notes/241.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Make `endDate` field optional when downloading GoCardless transactions.


### PR DESCRIPTION
There appears to be no strong reason for explicitly limiting the end date to today, and it's preventing proper integration with Bank Norwegian whose value dates actually represent when the interest-free period for the transaction ends and is therefore in the future. (#237)

After this is merged we can then remove the corresponding field from the Actual application.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
