### PR TITLE
Add FINTRO_BE_GEBABEBB GoCardless integration (Include additionalInformation in notes)

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -4,6 +4,7 @@ import IntegrationBank from './banks/integration-bank.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
+import FintroBeGebabebb from './banks/fintro-be-gebabebb.js'
 
 const banks = [
   AmericanExpressAesudef1,
@@ -11,6 +12,7 @@ const banks = [
   MbankRetailBrexplpw,
   SandboxfinanceSfin0000,
   NorwegianXxNorwnok1,
+  FintroBeGebabebb,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -4,7 +4,7 @@ import IntegrationBank from './banks/integration-bank.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
-import FintroBeGebabebb from './banks/fintro-be-gebabebb.js'
+import FintroBeGebabebb from './banks/fintro-be-gebabebb.js';
 
 const banks = [
   AmericanExpressAesudef1,

--- a/src/app-gocardless/banks/fintro-be-gebabebb.js
+++ b/src/app-gocardless/banks/fintro-be-gebabebb.js
@@ -1,0 +1,105 @@
+import {
+  sortByBookingDateOrValueDate,
+  amountToInteger,
+  printIban,
+} from '../utils.js';
+
+const SORTED_BALANCE_TYPE_LIST = [
+  'closingBooked',
+  'expected',
+  'forwardAvailable',
+  'interimAvailable',
+  'interimBooked',
+  'nonInvoiced',
+  'openingBooked',
+];
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  institutionIds: ['FINTRO_BE_GEBABEBB'],
+
+  normalizeAccount(account) {
+    console.log(
+      'Available account properties for new institution integration',
+      { account: JSON.stringify(account) },
+    );
+
+    return {
+      account_id: account.id,
+      institution: account.institution,
+      mask: (account?.iban || '0000').slice(-4),
+      iban: account?.iban || null,
+      name: [account.name, printIban(account), account.currency]
+        .filter(Boolean)
+        .join(' '),
+      official_name: `integration-${account.institution_id}`,
+      type: 'checking',
+    };
+  },
+
+  /** FINTRO_BE_GEBABEBB provides a lot of useful information via the 'additionalField'
+   *  There does not seem to be a specification of this field, but the following information is contained in its subfields:
+   *  - for pending transactions: the 'atmPosName'
+   *  - for booked transactions: the 'narrative'.
+   *  This narrative subfield is most useful as it contains information required to identify the transaction,
+   *  especially in case of debit card or instant payment transactions.
+   *  Do note that the narrative subfield ALSO contains the remittance information if any.
+   *  The goal of the  normalization is to place any relevant information of the additionalInformation
+   *  field in the remittanceInformationUnstructuredArray field.
+   */
+  normalizeTransaction(transaction, _booked) {
+    if (transaction.additionalInformation) {
+      let additionalInformationObject = {};
+      const additionalInfoRegex = /(, )?([^:]+): ((\[.*?\])|([^,]*))/g;
+      let matches =
+        transaction.additionalInformation.matchAll(additionalInfoRegex);
+      if (matches) {
+        for (let match of matches) {
+          let key = match[2].trim();
+          let value = (match[4] || match[5]).trim();
+          // Remove square brackets and single quotes and commas
+          value = value.replace(/[[\]',]/g, '');
+          additionalInformationObject[key] = value;
+        }
+        // Keep existing unstructuredArray and add atmPosName and narrative
+        transaction.remittanceInformationUnstructuredArray = [
+          transaction.remittanceInformationUnstructuredArray ?? '',
+          additionalInformationObject?.atmPosName ?? '',
+          additionalInformationObject?.narrative ?? '',
+        ].filter(Boolean);
+      }
+    }
+    return transaction;
+  },
+
+  sortTransactions(transactions = []) {
+    console.log(
+      'Available (first 10) transactions properties for new integration of institution in sortTransactions function',
+      { top10Transactions: JSON.stringify(transactions.slice(0, 10)) },
+    );
+    return sortByBookingDateOrValueDate(transactions);
+  },
+
+  calculateStartingBalance(sortedTransactions = [], balances = []) {
+    console.log(
+      'Available (first 10) transactions properties for new integration of institution in calculateStartingBalance function',
+      {
+        balances: JSON.stringify(balances),
+        top10SortedTransactions: JSON.stringify(
+          sortedTransactions.slice(0, 10),
+        ),
+      },
+    );
+
+    const currentBalance = balances
+      .filter((item) => SORTED_BALANCE_TYPE_LIST.includes(item.balanceType))
+      .sort(
+        (a, b) =>
+          SORTED_BALANCE_TYPE_LIST.indexOf(a.balanceType) -
+          SORTED_BALANCE_TYPE_LIST.indexOf(b.balanceType),
+      )[0];
+    return sortedTransactions.reduce((total, trans) => {
+      return total - amountToInteger(trans.transactionAmount.amount);
+    }, amountToInteger(currentBalance?.balanceAmount?.amount || 0));
+  },
+};

--- a/src/app-gocardless/gocardless-node.types.ts
+++ b/src/app-gocardless/gocardless-node.types.ts
@@ -436,6 +436,16 @@ export type Transaction = {
   remittanceInformationStructured?: string;
 
   /**
+   * Reference as contained in the unstructured remittance reference structure
+   */
+  remittanceInformationUnstructured?: string;
+
+  /**
+   * Reference as contained in the unstructured remittance array reference structure
+   */
+  remittanceInformationUnstructuredArray?: string[];
+
+  /**
    * The amount of the transaction as billed to the account
    */
   transactionAmount: Amount;

--- a/upcoming-release-notes/242.md
+++ b/upcoming-release-notes/242.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [CharlieMK]
+---
+
+Add GoCardless integration for Fintro BE to use additional transaction information.


### PR DESCRIPTION
Implements https://github.com/actualbudget/actual/issues/1466
Replaces https://github.com/actualbudget/actual/pull/1490
Uses @kyrias transaction normalization from https://github.com/actualbudget/actual-server/pull/237

Note that due to https://github.com/actualbudget/actual/pull/745, in case of **pending** transactions 'atmPosName' will be used for both the payeename and the notes field. This is because pending transactions do not have a payee name yet, but they do have an atmPosName in the additionalInformation field that I'm using. I would argue that we should not blindly put remittanceinformation in the payee name field (except perhaps for some banks), but I'm not removing that in this PR. 