### PR TITLE
Add DANSKEBANK_DABANO22 integration

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -5,6 +5,7 @@ import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
 import FintroBeGebabebb from './banks/fintro-be-gebabebb.js';
+import DanskeBankDabNO22 from './banks/danskebank-dabno22.js';
 
 const banks = [
   AmericanExpressAesudef1,
@@ -13,6 +14,7 @@ const banks = [
   SandboxfinanceSfin0000,
   NorwegianXxNorwnok1,
   FintroBeGebabebb,
+  DanskeBankDabNO22,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/banks/danskebank-dabno22.js
+++ b/src/app-gocardless/banks/danskebank-dabno22.js
@@ -1,0 +1,60 @@
+import {
+  printIban,
+  amountToInteger,
+  sortByBookingDateOrValueDate,
+} from '../utils.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  institutionIds: ['DANSKEBANK_DABANO22'],
+
+  normalizeAccount(account) {
+    return {
+      account_id: account.id,
+      institution: account.institution,
+      mask: account.iban.slice(-4),
+      iban: account.iban,
+      name: [account.name, printIban(account)].join(' '),
+      official_name: account.name,
+      type: 'checking',
+    };
+  },
+
+  normalizeTransaction(transaction, _booked) {
+    /**
+     * Danske Bank appends the EndToEndID: NOTPROVIDED to
+     * remittanceInformationUnstructured, cluttering the data.
+     *
+     * We clean thais up by removing any instances of this string from all transactions.
+     *
+     */
+    transaction.remittanceInformationUnstructured =
+      transaction.remittanceInformationUnstructured.replace(
+        '\nEndToEndID: NOTPROVIDED',
+        '',
+      );
+
+    /**
+     * The valueDate in transactions from Danske Bank is not the one expected, but rather the date
+     * the funds are expected to be paid back for credit accounts.
+     */
+    return {
+      ...transaction,
+      date: transaction.bookingDate,
+    };
+  },
+
+  sortTransactions(transactions = []) {
+    return sortByBookingDateOrValueDate(transactions);
+  },
+
+  calculateStartingBalance(sortedTransactions = [], balances = []) {
+    const currentBalance = balances.find(
+      (balance) => balance.balanceType === 'interimAvailable',
+    );
+
+    return sortedTransactions.reduce((total, trans) => {
+      return total - amountToInteger(trans.transactionAmount.amount);
+    }, amountToInteger(currentBalance.balanceAmount.amount));
+  },
+};

--- a/upcoming-release-notes/244.md
+++ b/upcoming-release-notes/244.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [LudvigHz]
+---
+
+Add GoCardless integration for Danske Bank Private NO


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

This PR adds an integration for `DANSKEBANK_DABANO22`.

The issue here is mostly similar to that fixed in #237 (`valueDate` is handled similarly), except from the issues with pending transactions (I _think_).

I'm going to take a wild guess here and say that the other branches of Danske Bank private (`DANSKEBANK_DABAFIHH`, `DANSKEBANK_DABADKKK`, `DANSKEBANK_DABASESX`, `DANSKEBANK_DABAGB2B`) _most likely_ exhibit the same behavior? But since I can't validate this I've just enabled this for the NO branch currently. Would love some feedback on this.

Another issue here is that I've only validated this behavior for the credit account. I have a checking account but don't really use it so I have no data on what that looks like, although I would expect it to not have the same issues with `valueDate`. 

Let me know if I should fall back to the default there or not. The only issue is that I would have to refactor a bit to get information about the account in order to differentiate the transactions between the account types. If it's easier to just keep `bookingDate` for all accounts I feel like that would be fine. But I can of course change that.


Regarding pending transactions, I have some in my bank right now I believe (they are marked as `reserved` in by banking app at least, but they still show up under booked transactions from GoCardless. So my guess here as well is that they just put everything in `booked` regardless of their actual status :facepalm:.
