### PR TITLE
Make file size uploads configurable via env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt
-      # - ACTUAL_FILE_SIZE_SYNC_LIMIT_MB=20
-      # - ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB=50
-      # - ACTUAL_FILE_SIZE_LIMIT_MB=20
+      # - ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB=20
+      # - ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB=50
+      # - ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB=20
       # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration
       # !! If you are not using any of these options, remove the 'environment:' tag entirely.
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt
-      # - ACTUAL_FILE_SYNC_LIMIT=20
-      # - ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT=50
-      # - ACTUAL_FILE_LIMIT=20
+      # - ACTUAL_FILE_SIZE_SYNC_LIMIT_MB=20
+      # - ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB=50
+      # - ACTUAL_FILE_SIZE_LIMIT_MB=20
       # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration
       # !! If you are not using any of these options, remove the 'environment:' tag entirely.
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt
+      # - ACTUAL_FILE_SYNC_LIMIT=20
+      # - ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT=50
+      # - ACTUAL_FILE_LIMIT=20
       # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration
       # !! If you are not using any of these options, remove the 'environment:' tag entirely.
     volumes:

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,7 @@ app.use(bodyParser.json({ limit: `${config.upload.fileSizeLimitMB}mb` }));
 app.use(
   bodyParser.raw({
     type: 'application/actual-sync',
-    limit: `${config.upload.fileSyncLimit}mb`,
+    limit: `${config.upload.fileSizeSyncLimitMB}mb`,
   }),
 );
 app.use(

--- a/src/app.js
+++ b/src/app.js
@@ -26,9 +26,9 @@ app.use(
     standardHeaders: true,
   }),
 );
-app.use(bodyParser.json({ limit: '20mb' }));
-app.use(bodyParser.raw({ type: 'application/actual-sync', limit: '20mb' }));
-app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '50mb' }));
+app.use(bodyParser.json({ limit: '40mb' }));
+app.use(bodyParser.raw({ type: 'application/actual-sync', limit: '40mb' }));
+app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '100mb' }));
 
 app.use('/sync', syncApp.handlers);
 app.use('/account', accountApp.handlers);

--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ app.use(
     standardHeaders: true,
   }),
 );
-app.use(bodyParser.json({ limit: `${config.upload.fileLimit}` }));
+app.use(bodyParser.json({ limit: `${config.upload.fileSizeLimitMB}mb` }));
 app.use(
   bodyParser.raw({
     type: 'application/actual-sync',

--- a/src/app.js
+++ b/src/app.js
@@ -37,7 +37,7 @@ app.use(
 app.use(
   bodyParser.raw({
     type: 'application/encrypted-file',
-    limit: `${config.upload.syncEncryptedFileLimit}mb`,
+    limit: `${config.upload.syncEncryptedFileSizeLimitMB}mb`,
   }),
 );
 

--- a/src/app.js
+++ b/src/app.js
@@ -26,9 +26,19 @@ app.use(
     standardHeaders: true,
   }),
 );
-app.use(bodyParser.json({ limit: '40mb' }));
-app.use(bodyParser.raw({ type: 'application/actual-sync', limit: '40mb' }));
-app.use(bodyParser.raw({ type: 'application/encrypted-file', limit: '100mb' }));
+app.use(bodyParser.json({ limit: `${config.upload.fileLimit}` }));
+app.use(
+  bodyParser.raw({
+    type: 'application/actual-sync',
+    limit: `${config.upload.fileSyncLimit}mb`,
+  }),
+);
+app.use(
+  bodyParser.raw({
+    type: 'application/encrypted-file',
+    limit: `${config.upload.syncEncryptedFileLimit}mb`,
+  }),
+);
 
 app.use('/sync', syncApp.handlers);
 app.use('/account', accountApp.handlers);

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -12,8 +12,8 @@ export interface Config {
     cert: string;
   } & ServerOptions;
   upload?: {
-    fileSyncLimit: number;
-    syncEncryptedFileLimit: number;
-    fileLimit: number;
+    fileSizeSyncLimitMB: number;
+    syncEncryptedFileSizeLimitMB: number;
+    fileSizeLimitMB: number;
   };
 }

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -11,4 +11,9 @@ export interface Config {
     key: string;
     cert: string;
   } & ServerOptions;
+  upload?: {
+    fileSyncLimit: number;
+    syncEncryptedFileLimit: number;
+    fileLimit: number;
+  };
 }

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -97,20 +97,21 @@ const finalConfig = {
         }
       : config.https,
   upload:
-    process.env.ACTUAL_FILE_SIZE_SYNC_LIMIT_MB ||
-    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
-    process.env.ACTUAL_FILE_SIZE_LIMIT_MB
+    process.env.ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB ||
+    process.env.ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB ||
+    process.env.ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB
       ? {
           fileSizeSyncLimitMB:
-            process.env.ACTUAL_FILE_SIZE_SYNC_LIMIT_MB ||
-            process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
-            20,
+            +process.env.ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB ||
+            +process.env.ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB ||
+            config.upload.fileSizeSyncLimitMB,
           syncEncryptedFileSizeLimitMB:
-            process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
-            process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
-            50,
-          fileSizeLimitMB: +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
-          ...(config.upload || {}),
+            +process.env.ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB ||
+            +process.env.ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB ||
+            config.upload.syncEncryptedFileSizeLimitMB,
+          fileSizeLimitMB:
+            +process.env.ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB ||
+            config.upload.fileSizeLimitMB,
         }
       : config.upload,
 };

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -92,8 +92,8 @@ const finalConfig = {
         }
       : config.https,
   upload:
-    process.env.ACTUAL_FILE_SYNC_LIMIT &&
-    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT &&
+    process.env.ACTUAL_FILE_SYNC_LIMIT ||
+    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
     process.env.ACTUAL_FILE_LIMIT
       ? {
           fileSyncLimit: +process.env.ACTUAL_FILE_SYNC_LIMIT || +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -101,15 +101,15 @@ const finalConfig = {
     process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
     process.env.ACTUAL_FILE_SIZE_LIMIT_MB
       ? {
-          fileSyncLimit:
+          fileSizeSyncLimitMB:
             process.env.ACTUAL_FILE_SIZE_SYNC_LIMIT_MB ||
             process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
             20,
-          syncEncryptedFileLimit:
+          syncEncryptedFileSizeLimitMB:
             process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
             process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
             50,
-          fileLimit: +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
+          fileSizeLimitMB: +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
           ...(config.upload || {}),
         }
       : config.upload,

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -96,9 +96,9 @@ const finalConfig = {
     process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT &&
     process.env.ACTUAL_FILE_LIMIT
       ? {
-          fileSyncLimit: +process.env.ACTUAL_FILE_SYNC_LIMIT || 20,
+          fileSyncLimit: +process.env.ACTUAL_FILE_SYNC_LIMIT || +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
           syncEncryptedFileLimit:
-            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT || 50,
+            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT || +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 50,
           fileLimit: +process.env.ACTUAL_FILE_LIMIT || 20,
           ...(config.upload || {}),
         }

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -85,6 +85,18 @@ const finalConfig = {
           ...(config.https || {}),
         }
       : config.https,
+  upload:
+    process.env.ACTUAL_FILE_SYNC_LIMIT &&
+    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT &&
+    process.env.ACTUAL_FILE_LIMIT
+      ? {
+          fileSyncLimit: +process.env.ACTUAL_FILE_SYNC_LIMIT || 20,
+          syncEncryptedFileLimit:
+            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT || 50,
+          fileLimit: +process.env.ACTUAL_FILE_LIMIT || 20,
+          ...(config.upload || {}),
+        }
+      : config.upload,
 };
 
 debug(`using port ${finalConfig.port}`);
@@ -98,6 +110,14 @@ if (finalConfig.https) {
   debugSensitive(`using https key ${finalConfig.https.key}`);
   debug(`using https cert: ${'*'.repeat(finalConfig.https.cert.length)}`);
   debugSensitive(`using https cert ${finalConfig.https.cert}`);
+}
+
+if (finalConfig.upload) {
+  debug(`using file sync limit ${finalConfig.upload.fileSyncLimit}`);
+  debug(
+    `using sync encrypted file limit ${finalConfig.upload.syncEncryptedFileLimit}`,
+  );
+  debug(`using file limit ${finalConfig.upload.fileLimit}`);
 }
 
 export default finalConfig;

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -96,9 +96,14 @@ const finalConfig = {
     process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
     process.env.ACTUAL_FILE_LIMIT
       ? {
-          fileSyncLimit: +process.env.ACTUAL_FILE_SYNC_LIMIT || +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
+          fileSyncLimit:
+            +process.env.ACTUAL_FILE_SYNC_LIMIT ||
+            +process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
+            20,
           syncEncryptedFileLimit:
-            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT || +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 50,
+            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
+            +process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
+            50,
           fileLimit: +process.env.ACTUAL_FILE_LIMIT || 20,
           ...(config.upload || {}),
         }

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -55,6 +55,11 @@ let defaultConfig = {
     'web',
     'build',
   ),
+  upload: {
+    fileSizeSyncLimitMB: 20,
+    syncEncryptedFileSizeLimitMB: 50,
+    fileSizeLimitMB: 20,
+  },
 };
 
 /** @type {import('./config-types.js').Config} */
@@ -104,7 +109,7 @@ const finalConfig = {
             +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
             +process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
             50,
-          fileLimit: +process.env.ACTUAL_FILE_LIMIT || 20,
+          fileLimit: +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
           ...(config.upload || {}),
         }
       : config.upload,

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -97,17 +97,17 @@ const finalConfig = {
         }
       : config.https,
   upload:
-    process.env.ACTUAL_FILE_SYNC_LIMIT ||
-    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
-    process.env.ACTUAL_FILE_LIMIT
+    process.env.ACTUAL_FILE_SIZE_SYNC_LIMIT_MB ||
+    process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
+    process.env.ACTUAL_FILE_SIZE_LIMIT_MB
       ? {
           fileSyncLimit:
-            +process.env.ACTUAL_FILE_SYNC_LIMIT ||
-            +process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
+            process.env.ACTUAL_FILE_SIZE_SYNC_LIMIT_MB ||
+            process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
             20,
           syncEncryptedFileLimit:
-            +process.env.ACTUAL_SYNC_ENCRYPTED_FILE_LIMIT ||
-            +process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
+            process.env.ACTUAL_SYNC_ENCRYPTED_FILE_SIZE_LIMIT_MB ||
+            process.env.ACTUAL_FILE_SIZE_LIMIT_MB ||
             50,
           fileLimit: +process.env.ACTUAL_FILE_SIZE_LIMIT_MB || 20,
           ...(config.upload || {}),

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -119,11 +119,11 @@ if (finalConfig.https) {
 }
 
 if (finalConfig.upload) {
-  debug(`using file sync limit ${finalConfig.upload.fileSyncLimit}`);
+  debug(`using file sync limit ${finalConfig.upload.fileSizeSyncLimitMB}mb`);
   debug(
-    `using sync encrypted file limit ${finalConfig.upload.syncEncryptedFileLimit}`,
+    `using sync encrypted file limit ${finalConfig.upload.syncEncryptedFileSizeLimitMB}mb`,
   );
-  debug(`using file limit ${finalConfig.upload.fileLimit}`);
+  debug(`using file limit ${finalConfig.upload.fileSizeLimitMB}mb`);
 }
 
 export default finalConfig;

--- a/upcoming-release-notes/245.md
+++ b/upcoming-release-notes/245.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: DistroByte
+---
+
+Increase file size limits to double previous value to eliminate `PayloadTooLargeError`

--- a/upcoming-release-notes/245.md
+++ b/upcoming-release-notes/245.md
@@ -1,6 +1,7 @@
 ---
 category: Features
-authors: DistroByte
+authors: 
+    - DistroByte
 ---
 
 Increase file size limits to double previous value to eliminate `PayloadTooLargeError`

--- a/upcoming-release-notes/245.md
+++ b/upcoming-release-notes/245.md
@@ -1,7 +1,7 @@
 ---
 category: Features
-authors: 
-    - DistroByte
+authors:
+  - DistroByte
 ---
 
-Increase file size limits to double previous value to eliminate `PayloadTooLargeError`
+Make upload limits configurable via env vars to allow for larger files to be uploaded.


### PR DESCRIPTION
The information contained in an actual budget is now much more detailed than it was previously. Doubling this file size should prevent errors

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
