### PR TITLE
Fix config file not being loaded from the project root by default

### DIFF
--- a/src/load-config.js
+++ b/src/load-config.js
@@ -10,7 +10,10 @@ const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 debug(`project root: '${projectRoot}'`);
 export const sqlDir = path.join(projectRoot, 'src', 'sql');
 
-let defaultDataDir = fs.existsSync(path.join(projectRoot, 'config.json')) ? projectRoot : '/data';
+let defaultDataDir = fs.existsSync(path.join(projectRoot, 'config.json'))
+  ? projectRoot
+  : '/data';
+
 debug(`default data directory: '${defaultDataDir}'`);
 
 function parseJSON(path, allowMissing = false) {

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -10,10 +10,7 @@ const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 debug(`project root: '${projectRoot}'`);
 export const sqlDir = path.join(projectRoot, 'src', 'sql');
 
-let defaultDataDir = fs.existsSync(path.join(projectRoot, 'config.json'))
-  ? projectRoot
-  : '/data';
-
+let defaultDataDir = fs.existsSync('/data') ? '/data' : projectRoot;
 debug(`default data directory: '${defaultDataDir}'`);
 
 function parseJSON(path, allowMissing = false) {
@@ -37,8 +34,14 @@ if (process.env.ACTUAL_CONFIG_PATH) {
   );
   userConfig = parseJSON(process.env.ACTUAL_CONFIG_PATH);
 } else {
-  debug(`loading config from default path: '${defaultDataDir}/config.json'`);
-  userConfig = parseJSON(path.join(defaultDataDir, 'config.json'), true);
+  let configFile = path.join(projectRoot, 'config.json');
+
+  if (!fs.existsSync(configFile)) {
+    configFile = path.join(defaultDataDir, 'config.json');
+  }
+
+  debug(`loading config from default path: '${configFile}'`);
+  userConfig = parseJSON(configFile, true);
 }
 
 /** @type {Omit<import('./config-types.js').Config, 'mode' | 'serverFiles' | 'userFiles'>} */

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -10,7 +10,7 @@ const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 debug(`project root: '${projectRoot}'`);
 export const sqlDir = path.join(projectRoot, 'src', 'sql');
 
-let defaultDataDir = fs.existsSync('/data') ? '/data' : projectRoot;
+let defaultDataDir = fs.existsSync(path.join(projectRoot, 'config.json')) ? projectRoot : '/data';
 debug(`default data directory: '${defaultDataDir}'`);
 
 function parseJSON(path, allowMissing = false) {

--- a/upcoming-release-notes/249.md
+++ b/upcoming-release-notes/249.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [UnexomWid]
 ---
 
-Fix default data dir when the config exists in the project root
+Fix config file not being loaded from the project root by default

--- a/upcoming-release-notes/249.md
+++ b/upcoming-release-notes/249.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnexomWid]
+---
+
+Fix default data dir when the config exists in the project root


### PR DESCRIPTION
Solves #246 by loading the config from the project root if it exists there.