### PR TITLE
:fire:  remove jlongster/actual-server package

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -23,7 +23,6 @@ env:
   IMAGES: |
     actualbudget/actual-server
     ghcr.io/actualbudget/actual-server
-    jlongster/actual-server
 
   # Creates the following tags:
   # - actual-server:edge

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,7 +13,6 @@ env:
   IMAGES: |
     actualbudget/actual-server
     ghcr.io/actualbudget/actual-server
-    jlongster/actual-server
 
   # Creates the following tags:
   # - actual-server:latest (see docker/metadata-action flavor inputs, below)

--- a/upcoming-release-notes/260.md
+++ b/upcoming-release-notes/260.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Removing deprecated `jlongster/actual-server`


### PR DESCRIPTION
Removing `jlongster/actual-server`. This was deprecated a long time ago ([April 2023](https://github.com/actualbudget/docs/blob/7a90e1e2c730dba00b23bca514db7361c4de2747/blog/2023-04-16-release-23.4.0.md?plain=1#L12)). 