### PR TITLE
Make edge builds fetch master builds from correct repository

### DIFF
--- a/docker/edge-alpine.Dockerfile
+++ b/docker/edge-alpine.Dockerfile
@@ -8,7 +8,7 @@ RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --bu
 
 RUN mkdir /public
 ADD artifacts.json /tmp/artifacts.json
-RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master")][0]' /tmp/artifacts.json > /tmp/latest-build.json
+RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master" and .workflow_run.head_repository_id == .workflow_run.repository_id)][0]' /tmp/artifacts.json > /tmp/latest-build.json
 
 ARG GITHUB_TOKEN
 RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_TOKEN}" $(jq -r '.archive_download_url' /tmp/latest-build.json)

--- a/docker/edge-ubuntu.Dockerfile
+++ b/docker/edge-ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN yarn workspaces focus --all --production
 
 RUN mkdir /public
 ADD artifacts.json /tmp/artifacts.json
-RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master")][0]' /tmp/artifacts.json > /tmp/latest-build.json
+RUN jq -r '[.artifacts[] | select(.workflow_run.head_branch == "master" and .workflow_run.head_repository_id == .workflow_run.repository_id)][0]' /tmp/artifacts.json > /tmp/latest-build.json
 
 ARG GITHUB_TOKEN
 RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_TOKEN}" $(jq -r '.archive_download_url' /tmp/latest-build.json)

--- a/upcoming-release-notes/265.md
+++ b/upcoming-release-notes/265.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [kyrias]
+---
+
+Make edge builds fetch master builds from correct repository.


### PR DESCRIPTION
If we don't verify that the repository ID is what we expected then we will pull artifacts from PRs where the source branch is `master`.