### PR TITLE
Add "docker.io/" registry prefix to docker compose image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   actual_server:
-    image: actualbudget/actual-server:latest
+    image: docker.io/actualbudget/actual-server:latest
     ports:
       # This line makes Actual available at port 5006 of the device you run the server on,
       # i.e. http://localhost:5006. You can change the first number to change the port, if you want.

--- a/upcoming-release-notes/274.md
+++ b/upcoming-release-notes/274.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Valloric]
+---
+
+Add "docker.io/" registry prefix to docker compose image


### PR DESCRIPTION
Required by Podman Compose. Docker Compose should not care either way. The registry prefix is explicitly supported in the [compose file spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image)

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
