### PR TITLE
:bug: (gocardless) fix banksync - create singleton client

### DIFF
--- a/src/app-gocardless/services/gocardless-service.js
+++ b/src/app-gocardless/services/gocardless-service.js
@@ -18,11 +18,22 @@ import { SecretName, secretsService } from '../../services/secrets-service.js';
 
 const GoCardlessClient = nordigenNode.default;
 
-const getGocardlessClient = () =>
-  new GoCardlessClient({
+const clients = new Map();
+
+const getGocardlessClient = () => {
+  const secrets = {
     secretId: secretsService.get(SecretName.nordigen_secretId),
     secretKey: secretsService.get(SecretName.nordigen_secretKey),
-  });
+  };
+
+  const hash = JSON.stringify(secrets);
+
+  if (!clients.has(hash)) {
+    clients.set(hash, new GoCardlessClient(secrets));
+  }
+
+  return clients.get(hash);
+};
 
 export const handleGoCardlessError = (response) => {
   switch (response.status_code) {

--- a/upcoming-release-notes/278.md
+++ b/upcoming-release-notes/278.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix: gocardless bank sync not working as expected after last migration PR merge


### PR DESCRIPTION
https://github.com/actualbudget/actual-server/pull/267 introduced a small regression: the client is re-created every time it is used. Obviously this causes some problems as the access tokens get reset very often..

Instead I am now using a singleton client that is mapped by the secrets. Meaning: when secrets change we will generate a new client.