### PR TITLE
Changed fintro specific bank integration to work with BNP and Hello Bank

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -4,7 +4,7 @@ import IntegrationBank from './banks/integration-bank.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
-import FintroBeGebabebb from './banks/fintro-be-gebabebb.js';
+import BnpBeGebabebb from './banks/bnp-be-gebabebb.js';
 import DanskeBankDabNO22 from './banks/danskebank-dabno22.js';
 import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
 import Belfius from './banks/belfius_gkccbebb.js';
@@ -15,7 +15,7 @@ const banks = [
   MbankRetailBrexplpw,
   SandboxfinanceSfin0000,
   NorwegianXxNorwnok1,
-  FintroBeGebabebb,
+  BnpBeGebabebb,
   DanskeBankDabNO22,
   SparNordSpNoDK22,
   Belfius,

--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -16,7 +16,11 @@ const SORTED_BALANCE_TYPE_LIST = [
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
-  institutionIds: ['FINTRO_BE_GEBABEBB', 'HELLO_BE_GEBABEBB', 'BNP_BE_GEBABEBB'],
+  institutionIds: [
+    'FINTRO_BE_GEBABEBB', 
+    'HELLO_BE_GEBABEBB',
+    'BNP_BE_GEBABEBB'
+  ],
 
   normalizeAccount(account) {
     return {

--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -16,7 +16,7 @@ const SORTED_BALANCE_TYPE_LIST = [
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
-  institutionIds: ['FINTRO_BE_GEBABEBB'],
+  institutionIds: ['FINTRO_BE_GEBABEBB', 'HELLO_BE_GEBABEBB', 'BNP_BE_GEBABEBB'],
 
   normalizeAccount(account) {
     return {
@@ -32,7 +32,7 @@ export default {
     };
   },
 
-  /** FINTRO_BE_GEBABEBB provides a lot of useful information via the 'additionalField'
+  /** BNP_BE_GEBABEBB provides a lot of useful information via the 'additionalField'
    *  There does not seem to be a specification of this field, but the following information is contained in its subfields:
    *  - for pending transactions: the 'atmPosName'
    *  - for booked transactions: the 'narrative'.

--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -17,9 +17,9 @@ const SORTED_BALANCE_TYPE_LIST = [
 /** @type {import('./bank.interface.js').IBank} */
 export default {
   institutionIds: [
-    'FINTRO_BE_GEBABEBB', 
+    'FINTRO_BE_GEBABEBB',
     'HELLO_BE_GEBABEBB',
-    'BNP_BE_GEBABEBB'
+    'BNP_BE_GEBABEBB',
   ],
 
   normalizeAccount(account) {

--- a/upcoming-release-notes/285.md
+++ b/upcoming-release-notes/285.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [feliciaan]
+---
+
+Fix: add fixes for BNP Paribas Fortis and Hello Bank


### PR DESCRIPTION
Change the gocardless integration that works for Fintro (subbrand) to also work with the main institution (BNP) and another brand of the bank (Hello Bank). Also rename of the file to the main brand.