### PR TITLE
Store migrations statestore in datadir

### DIFF
--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -2,6 +2,7 @@ import { ServerOptions } from 'https';
 
 export interface Config {
   mode: 'test' | 'development';
+  dataDir: string;
   port: number;
   hostname: string;
   serverFiles: string;

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -44,7 +44,7 @@ if (process.env.ACTUAL_CONFIG_PATH) {
   userConfig = parseJSON(configFile, true);
 }
 
-/** @type {Omit<import('./config-types.js').Config, 'mode' | 'serverFiles' | 'userFiles'>} */
+/** @type {Omit<import('./config-types.js').Config, 'mode' | 'dataDir' | 'serverFiles' | 'userFiles'>} */
 let defaultConfig = {
   port: 5006,
   hostname: '::',
@@ -67,6 +67,7 @@ let config;
 if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'test',
+    dataDir: projectRoot,
     serverFiles: path.join(projectRoot, 'test-server-files'),
     userFiles: path.join(projectRoot, 'test-user-files'),
     ...defaultConfig,
@@ -75,6 +76,7 @@ if (process.env.NODE_ENV === 'test') {
   config = {
     mode: 'development',
     ...defaultConfig,
+    dataDir: defaultDataDir,
     serverFiles: path.join(defaultDataDir, 'server-files'),
     userFiles: path.join(defaultDataDir, 'user-files'),
     ...(userConfig || {}),

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -1,4 +1,5 @@
 import migrate from 'migrate';
+import path from 'node:path';
 import config from './load-config.js';
 
 export default function run(direction = 'up') {
@@ -9,7 +10,9 @@ export default function run(direction = 'up') {
   return new Promise((resolve) =>
     migrate.load(
       {
-        stateStore: `.migrate${config.mode === 'test' ? '-test' : ''}`,
+        stateStore: `${path.join(config.dataDir, '.migrate')}${
+          config.mode === 'test' ? '-test' : ''
+        }`,
       },
       (err, set) => {
         if (err) {

--- a/upcoming-release-notes/289.md
+++ b/upcoming-release-notes/289.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [bjw-s]
+---
+
+Store the migrations statestore in the datadir instead of the application root.


### PR DESCRIPTION
This PR makes it so the `.migrations` file gets stored in the `dataDir` instead of the application root. This should fix #288 and https://github.com/actualbudget/actual/issues/2011.