### PR TITLE
update os packages to resolve CVEs

### DIFF
--- a/docker/edge-alpine.Dockerfile
+++ b/docker/edge-alpine.Dockerfile
@@ -16,7 +16,7 @@ RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_
 RUN unzip /tmp/desktop-client.zip -d /public
 
 FROM alpine:3.17 as prod
-RUN apk add --no-cache nodejs tini
+RUN apk update && apk upgrade && apk add --no-cache nodejs tini
 
 ARG USERNAME=actual
 ARG USER_UID=1001

--- a/docker/edge-ubuntu.Dockerfile
+++ b/docker/edge-ubuntu.Dockerfile
@@ -15,7 +15,7 @@ RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_
 RUN unzip /tmp/desktop-client.zip -d /public
 
 FROM node:18-bullseye-slim as prod
-RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=actual
 ARG USER_UID=1001

--- a/docker/stable-alpine.Dockerfile
+++ b/docker/stable-alpine.Dockerfile
@@ -8,7 +8,7 @@ RUN yarn workspaces focus --all --production
 RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --build-from-source; fi
 
 FROM alpine:3.17 as prod
-RUN apk add --no-cache nodejs tini
+RUN apk update && apk upgrade && apk add --no-cache nodejs tini
 
 ARG USERNAME=actual
 ARG USER_UID=1001

--- a/docker/stable-ubuntu.Dockerfile
+++ b/docker/stable-ubuntu.Dockerfile
@@ -7,7 +7,7 @@ RUN if [ "$(uname -m)" = "armv7l" ]; then yarn config set taskPoolConcurrency 2;
 RUN yarn workspaces focus --all --production
 
 FROM node:18-bullseye-slim as prod
-RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=actual
 ARG USER_UID=1001

--- a/upcoming-release-notes/304.md
+++ b/upcoming-release-notes/304.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [hkiang01]
+---
+
+Update OS packages to automatically resolve CVEs


### PR DESCRIPTION
For example, in a recent build, some libraries were updated to resolve 4 CVEs in the alpine image per `trivy image` compared to the latest available edge builds