### PR TITLE
Update the nordigen-node gem to get new endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express-response-size": "^0.0.3",
     "jws": "^4.0.0",
     "migrate": "^2.0.1",
-    "nordigen-node": "^1.2.6",
+    "nordigen-node": "^1.3.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/upcoming-release-notes/310.md
+++ b/upcoming-release-notes/310.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Switch from using deprecated gocardless endpoints.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,7 +1639,7 @@ __metadata:
     jest: "npm:^29.3.1"
     jws: "npm:^4.0.0"
     migrate: "npm:^2.0.1"
-    nordigen-node: "npm:^1.2.6"
+    nordigen-node: "npm:^1.3.0"
     prettier: "npm:^2.8.3"
     supertest: "npm:^6.3.1"
     typescript: "npm:^4.9.5"
@@ -4831,13 +4831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nordigen-node@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "nordigen-node@npm:1.2.6"
+"nordigen-node@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "nordigen-node@npm:1.3.0"
   dependencies:
     axios: "npm:^1.2.1"
     dotenv: "npm:^10.0.0"
-  checksum: 2a148a206e5b9ff30565dcc330057ff4f083bf389e3fe84e45d75505376c912d3a754d9332aad79b0c679959431b84bc8d8f66b4501e88afe5b4a74aa22e1cdd
+  checksum: 033771af257ecf8e36a375b07e10246b08d23b647ef2db737b6efe52a1bcd68f04c88c2aff6790d4cbcd00da0148550247624142a6eea7444d370b2e65f08fc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to the new released version to get https://github.com/nordigen/nordigen-node/pull/57

It looks like actual gocardless users only have until the 20th to rollout this change.

The email:

```
Dear user,

We are contacting you to make sure you are using an up-to-date base_url for the GoCardless Bank Account Data API.
This small but important change which should be easy to make for anyone in your team who has access to the production setup of your service. The new connection string should be:
https://bankaccountdata.gocardless.com/api/v2/

The legacy URLs such as [ob.nordigen.com](http://ob.nordigen.com/) and [ob.gocardless.com](http://ob.gocardless.com/) will stop working on the 20th of February.

If you are using any of our public libraries, they are updated and can be found here:
https://developer.gocardless.com/bank-account-data/libraries

We would also like to inform you that there is maintenance window (with downtime) scheduled for 20.02.2024 between 03:00 and 05:00 UTC. You follow its progress on our statuspage:
https://status.nordigen.com/

If you have any questions, feel free to contact support by replying to this mail and will be happy to assist you.

Working on an ever better service,
Bank Account Data Team
```