### PR TITLE
Fix the link page for gocardless

### DIFF
--- a/src/app-gocardless/services/gocardless-service.js
+++ b/src/app-gocardless/services/gocardless-service.js
@@ -261,7 +261,7 @@ export const goCardlessService = {
     await goCardlessService.setToken();
 
     const response = await client.initSession({
-      redirectUrl: host + '/nordigen/link',
+      redirectUrl: host + '/gocardless/link',
       institutionId,
       referenceId: uuid.v4(),
       accessValidForDays,

--- a/upcoming-release-notes/311.md
+++ b/upcoming-release-notes/311.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix the redirect for gocardless link so the page closes when complete.


### PR DESCRIPTION
Ensures the redirect page is auto-closed after linking

After we dropped the nordigen endpoint in https://github.com/actualbudget/actual-server/pull/293 this was no longer working.

(Closing the redirect page automatically will typically reveal the previous tab which is the waiting actual page, where you can then setup next steps)