### PR TITLE
Pending Transaction Support for SimpleFIN Integration

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -96,11 +96,11 @@ app.post('/transactions', async (req, res) => {
 
       let dateToUse = 0;
 
-      if(trans.posted == 0) {
+      if( trans.posted == 0) {
         newTrans.booked = false;
         dateToUse = trans.transacted_at;
       } else {
-        newTrans.booked = true;      
+        newTrans.booked = true;
         dateToUse = trans.posted;
       }
 
@@ -118,7 +118,7 @@ app.post('/transactions', async (req, res) => {
         .toISOString()
         .split('T')[0];
 
-      if(newTrans.booked) {
+      if( newTrans.booked) {
         bookedTransactions.push(newTrans);
       } else {
         pendingTransactions.push(newTrans);

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -88,32 +88,52 @@ app.post('/transactions', async (req, res) => {
     response.startingBalance = balance; // could be named differently in this use case.
 
     let allTransactions = [];
+    let bookedTransactions = [];
+    let pendingTransactions = [];
 
     for (let trans of account.transactions) {
       let newTrans = {};
 
-      //newTrans.bankTransactionCode = don't have compared to GoCardless
-      newTrans.booked = true;
-      newTrans.bookingDate = new Date(trans.posted * 1000)
+      let dateToUse = 0;
+
+      if(trans.posted == 0) {
+
+        newTrans.booked = false;
+        dateToUse = trans.transacted_at;
+
+      } else {
+
+        newTrans.booked = true;      
+        dateToUse = trans.posted;
+
+      }
+
+      newTrans.bookingDate = new Date(dateToUse * 1000)
         .toISOString()
         .split('T')[0];
-      newTrans.date = new Date(trans.posted * 1000).toISOString().split('T')[0];
+
+      newTrans.date = new Date(dateToUse * 1000).toISOString().split('T')[0];
       newTrans.debtorName = trans.payee;
       //newTrans.debtorAccount = don't have compared to GoCardless
       newTrans.remittanceInformationUnstructured = trans.description;
       newTrans.transactionAmount = { amount: trans.amount, currency: 'USD' };
       newTrans.transactionId = trans.id;
-      newTrans.valueDate = new Date(trans.posted * 1000)
+      newTrans.valueDate = new Date(dateToUse * 1000)
         .toISOString()
         .split('T')[0];
 
+      if(newTrans.booked) {
+        bookedTransactions.push(newTrans);
+      } else {
+        pendingTransactions.push(newTrans);
+      }
       allTransactions.push(newTrans);
     }
 
     response.transactions = {
-      all: allTransactions,
-      booked: allTransactions,
-      pending: [],
+        all: allTransactions,
+        booked: bookedTransactions,
+        pending: pendingTransactions,
     };
 
     res.send({
@@ -202,6 +222,9 @@ async function getAccounts(accessKey, startDate, endDate) {
   if (endDate) {
     params.push(`end-date=${normalizeDate(endDate)}`);
   }
+  
+  params.push(`pending=1`);
+
   if (params.length > 0) {
     queryString += '?' + params.join('&');
   }

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -97,15 +97,11 @@ app.post('/transactions', async (req, res) => {
       let dateToUse = 0;
 
       if(trans.posted == 0) {
-
         newTrans.booked = false;
         dateToUse = trans.transacted_at;
-
       } else {
-
         newTrans.booked = true;      
         dateToUse = trans.posted;
-
       }
 
       newTrans.bookingDate = new Date(dateToUse * 1000)
@@ -131,9 +127,9 @@ app.post('/transactions', async (req, res) => {
     }
 
     response.transactions = {
-        all: allTransactions,
-        booked: bookedTransactions,
-        pending: pendingTransactions,
+      all: allTransactions,
+      booked: bookedTransactions,
+      pending: pendingTransactions,
     };
 
     res.send({
@@ -222,7 +218,7 @@ async function getAccounts(accessKey, startDate, endDate) {
   if (endDate) {
     params.push(`end-date=${normalizeDate(endDate)}`);
   }
-  
+
   params.push(`pending=1`);
 
   if (params.length > 0) {

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -96,7 +96,7 @@ app.post('/transactions', async (req, res) => {
 
       let dateToUse = 0;
 
-      if( trans.posted == 0) {
+      if (trans.posted == 0) {
         newTrans.booked = false;
         dateToUse = trans.transacted_at;
       } else {
@@ -118,7 +118,7 @@ app.post('/transactions', async (req, res) => {
         .toISOString()
         .split('T')[0];
 
-      if( newTrans.booked) {
+      if (newTrans.booked) {
         bookedTransactions.push(newTrans);
       } else {
         pendingTransactions.push(newTrans);

--- a/upcoming-release-notes/315.md
+++ b/upcoming-release-notes/315.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [duplaja]
+---
+
+Add pending transaction import and handling, where supported, to SimpleFIN integration.


### PR DESCRIPTION
This pull request adds pending transaction support for SimpleFIN (for the accounts that support pending transactions).

It follows the lead of the GoCardless integration, by importing pending transactions initially as uncleared, and then clearing when the transactions post.