### PR TITLE
Add ACTUAL_PORT environment variable to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt
+      # - ACTUAL_PORT=5006
       # - ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB=20
       # - ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB=50
       # - ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB=20

--- a/upcoming-release-notes/333.md
+++ b/upcoming-release-notes/333.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Add ACTUAL_PORT environment variable to docker-compose.yml


### PR DESCRIPTION
It can be difficult to see how to bind Actual server to a different port when using `docker compose`.  This adds a (commented out) environment variable for `ACTUAL_PORT` to make that more obvious to users.