### PR TITLE
Make running app.js cwd agnostic, extend config to allow changing dataDir

### DIFF
--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -3,6 +3,7 @@ import { ServerOptions } from 'https';
 export interface Config {
   mode: 'test' | 'development';
   dataDir: string;
+  projectRoot: string;
   port: number;
   hostname: string;
   serverFiles: string;

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -33,6 +33,8 @@ if (process.env.ACTUAL_CONFIG_PATH) {
     `loading config from ACTUAL_CONFIG_PATH: '${process.env.ACTUAL_CONFIG_PATH}'`,
   );
   userConfig = parseJSON(process.env.ACTUAL_CONFIG_PATH);
+
+  defaultDataDir = userConfig.dataDir ?? defaultDataDir;
 } else {
   let configFile = path.join(projectRoot, 'config.json');
 
@@ -60,6 +62,7 @@ let defaultConfig = {
     syncEncryptedFileSizeLimitMB: 50,
     fileSizeLimitMB: 20,
   },
+  projectRoot,
 };
 
 /** @type {import('./config-types.js').Config} */

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -123,6 +123,7 @@ const finalConfig = {
 
 debug(`using port ${finalConfig.port}`);
 debug(`using hostname ${finalConfig.hostname}`);
+debug(`using data directory ${finalConfig.dataDir}`);
 debug(`using server files directory ${finalConfig.serverFiles}`);
 debug(`using user files directory ${finalConfig.userFiles}`);
 debug(`using web root directory ${finalConfig.webRoot}`);

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -13,6 +13,7 @@ export default function run(direction = 'up') {
         stateStore: `${path.join(config.dataDir, '.migrate')}${
           config.mode === 'test' ? '-test' : ''
         }`,
+        migrationsDirectory: `${path.join(config.projectRoot, 'migrations')}`,
       },
       (err, set) => {
         if (err) {

--- a/upcoming-release-notes/341.md
+++ b/upcoming-release-notes/341.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Make running app.js cwd agnostic and extend config options to allow changing dataDir


### PR DESCRIPTION
Fixes #339 and fixes #340 
