### PR TITLE
Make /admin/login return a descriptive error when no password is provided

### DIFF
--- a/src/account-db.js
+++ b/src/account-db.js
@@ -49,7 +49,7 @@ export function bootstrap(password) {
 }
 
 export function login(password) {
-  if (password == null || password === '') {
+  if (password === undefined || password === '') {
     return { error: 'invalid-password' };
   }
 

--- a/src/account-db.js
+++ b/src/account-db.js
@@ -49,8 +49,13 @@ export function bootstrap(password) {
 }
 
 export function login(password) {
+  if (password == null || password === '') {
+    return { error: 'invalid-password' };
+  }
+
   let accountDb = getAccountDb();
   let row = accountDb.first('SELECT * FROM auth');
+
   let confirmed = row && bcrypt.compareSync(password, row.password);
 
   if (confirmed) {
@@ -59,7 +64,7 @@ export function login(password) {
     // "session" that times out after a long time or something, and
     // maybe each device has a different token
     let row = accountDb.first('SELECT * FROM sessions');
-    return row.token;
+    return { token: row.token };
   } else {
     return null;
   }

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -38,8 +38,14 @@ app.post('/bootstrap', (req, res) => {
 });
 
 app.post('/login', (req, res) => {
-  let token = login(req.body.password);
-  res.send({ status: 'ok', data: { token } });
+  let { error, token } = login(req.body.password);
+
+  if (error) {
+    res.status(400).send({ status: 'error', reason: error });
+    return;
+  } else {
+    res.send({ status: 'ok', data: { token } });
+  }
 });
 
 app.post('/change-password', (req, res) => {

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -43,9 +43,9 @@ app.post('/login', (req, res) => {
   if (error) {
     res.status(400).send({ status: 'error', reason: error });
     return;
-  } else {
-    res.send({ status: 'ok', data: { token } });
   }
+
+  res.send({ status: 'ok', data: { token } });
 });
 
 app.post('/change-password', (req, res) => {

--- a/upcoming-release-notes/342.md
+++ b/upcoming-release-notes/342.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Make /admin/login return a descriptive error when no password is provided


### PR DESCRIPTION
Fixes #308 

This change makes `/account/login` consistent with other non-authenticated endpoints and adds a more descriptive error message when no password is provided in the request body.

Before
```sh
% curl -X POST http://localhost:5006/account/login                                                                                                                                                                                                                   
{"status":"error","reason":"internal-error"}
```

After
```sh
% curl -X POST http://localhost:5006/account/login                                                                                                                                                                                                                   
{"status":"error","reason":"invalid-password"}
```