### PR TITLE
Add backup date field for GoCardless transactions with bank BNP_BE_GEBABEBB

### DIFF
--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -73,7 +73,7 @@ export default {
 
     return {
       ...transaction,
-      date: transaction.valueDate,
+      date: transaction.valueDate || transaction.bookingDate,
     };
   },
 

--- a/upcoming-release-notes/345.md
+++ b/upcoming-release-notes/345.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Add backup date field for GoCardless transactions with bank BNP_BE_GEBABEBB


### PR DESCRIPTION
Fixes #344 

As discussed on Discord, pending transactions do not come through from this bank with a valueDate set, only bookingDate.

However bookingDate is close enough to valueDate that the transaction will deduplicate when booked so we will use bookingDate until valueDate is available.
