### PR TITLE
fill in creditor name for BNP bank transactions

### DIFF
--- a/upcoming-release-notes/349.md
+++ b/upcoming-release-notes/349.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [vojeroen]
+---
+
+Ensure payee names don't contain transactional information when pulling in transactions from BNP bank with GoCardless.


### PR DESCRIPTION
Ensure payee names don't contain transactional information when pulling in transactions from BNP bank with GoCardless. 