### PR TITLE
Extend bank adapter for SEB Kort

### DIFF
--- a/src/app-gocardless/banks/seb-kort-bank-ab.js
+++ b/src/app-gocardless/banks/seb-kort-bank-ab.js
@@ -6,7 +6,7 @@ import {
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
-  institutionIds: ['SEB_KORT_AB_SE_SKHSFI21'],
+  institutionIds: ['SEB_KORT_AB_NO_SKHSFI21','SEB_KORT_AB_SE_SKHSFI21'],
 
   accessValidForDays: 180,
 

--- a/src/app-gocardless/banks/seb-kort-bank-ab.js
+++ b/src/app-gocardless/banks/seb-kort-bank-ab.js
@@ -6,7 +6,7 @@ import {
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
-  institutionIds: ['SEB_KORT_AB_NO_SKHSFI21','SEB_KORT_AB_SE_SKHSFI21'],
+  institutionIds: ['SEB_KORT_AB_NO_SKHSFI21', 'SEB_KORT_AB_SE_SKHSFI21'],
 
   accessValidForDays: 180,
 
@@ -44,11 +44,11 @@ export default {
   },
 
   /**
-   *  For SEB_KORT_AB_SE_SKHSFI21 we don't know what balance was
+   *  For SEB_KORT_AB_NO_SKHSFI21 and SEB_KORT_AB_SE_SKHSFI21 we don't know what balance was
    *  after each transaction so we have to calculate it by getting
    *  current balance from the account and subtract all the transactions
    *
-   *  As a current balance we use `expected` balance type because it
+   *  As a current balance we use `expected` and `nonInvoiced` balance types because it
    *  corresponds to the current running balance, whereas `interimAvailable`
    *  holds the remaining credit limit.
    */
@@ -57,8 +57,12 @@ export default {
       (balance) => 'expected' === balance.balanceType,
     );
 
+    const nonInvoiced = balances.find(
+      (balance) => 'nonInvoiced' === balance.balanceType,
+    );
+
     return sortedTransactions.reduce((total, trans) => {
       return total - amountToInteger(trans.transactionAmount.amount);
-    }, -amountToInteger(currentBalance.balanceAmount.amount));
+    }, -amountToInteger(currentBalance.balanceAmount.amount) + amountToInteger(nonInvoiced.balanceAmount.amount));
   },
 };

--- a/upcoming-release-notes/350.md
+++ b/upcoming-release-notes/350.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jakoblover]
+---
+
+Extended bank adapter for SEB to support SEB_KORT_AB_NO_SKHSFI21


### PR DESCRIPTION
`SEB_KORT_AB_NO_SKHSFI21` behaves like `SEB_KORT_AB_SE_SKHSFI21`. Added `SEB_KORT_AB_NO_SKHSFI21` to the list of institutions in the bank adapter for SEB Kort. 

~~I'm not able to get the correct starting balance. It seems like the transactions array does not include the non-invoiced transactions, only the booked transactions. In the overview of transactions, however, the non-invoiced transactions are listed. The starting balance is missing the amount equivalent of the non-invoiced transactions. Could use some help here.~~

Seems like I am able to get the correct starting balance after all. I had to connect the accont to gocardless again for it to recalculate the starting balance.