### PR TITLE
Add bank handler for `VIRGIN_NRNBGB22` (Virgin Money)

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -15,6 +15,7 @@ import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
 import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
 import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
+import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
 
 export const banks = [
   AbancaCaglesmm,
@@ -33,6 +34,7 @@ export const banks = [
   SparNordSpNoDK22,
   SpkMarburgBiedenkopfHeladef1mar,
   SpkKarlsruhekarsde66,
+  VirginNrnbgb22,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/banks/tests/virgin_nrnbgb22.spec.js
+++ b/src/app-gocardless/banks/tests/virgin_nrnbgb22.spec.js
@@ -15,8 +15,6 @@ describe('Virgin', () => {
         true,
       );
 
-      console.log(normalizedTransaction);
-
       expect(normalizedTransaction.creditorName).toEqual(
         'DIRECT DEBIT PAYMENT',
       );

--- a/src/app-gocardless/banks/tests/virgin_nrnbgb22.spec.js
+++ b/src/app-gocardless/banks/tests/virgin_nrnbgb22.spec.js
@@ -1,0 +1,67 @@
+import Virgin from '../virgin_nrnbgb22.js';
+import { mockTransactionAmount } from '../../services/tests/fixtures.js';
+
+describe('Virgin', () => {
+  describe('#normalizeTransaction', () => {
+    it('does not alter simple payee information', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+        remittanceInformationUnstructured: 'DIRECT DEBIT PAYMENT',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Virgin.normalizeTransaction(
+        transaction,
+        true,
+      );
+
+      console.log(normalizedTransaction);
+
+      expect(normalizedTransaction.creditorName).toEqual(
+        'DIRECT DEBIT PAYMENT',
+      );
+      expect(normalizedTransaction.debtorName).toEqual('DIRECT DEBIT PAYMENT');
+      expect(normalizedTransaction.remittanceInformationUnstructured).toEqual(
+        'DIRECT DEBIT PAYMENT',
+      );
+    });
+
+    it('formats bank transfer payee and references', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+        remittanceInformationUnstructured: 'FPS, Joe Bloggs, Food',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Virgin.normalizeTransaction(
+        transaction,
+        true,
+      );
+
+      expect(normalizedTransaction.creditorName).toEqual('Joe Bloggs');
+      expect(normalizedTransaction.debtorName).toEqual('Joe Bloggs');
+      expect(normalizedTransaction.remittanceInformationUnstructured).toEqual(
+        'Food',
+      );
+    });
+
+    it('removes method information from payee name', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+        remittanceInformationUnstructured: 'Card 99, Tesco Express',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Virgin.normalizeTransaction(
+        transaction,
+        true,
+      );
+
+      expect(normalizedTransaction.creditorName).toEqual('Tesco Express');
+      expect(normalizedTransaction.debtorName).toEqual('Tesco Express');
+      expect(normalizedTransaction.remittanceInformationUnstructured).toEqual(
+        'Card 99, Tesco Express',
+      );
+    });
+  });
+});

--- a/src/app-gocardless/banks/virgin_nrnbgb22.js
+++ b/src/app-gocardless/banks/virgin_nrnbgb22.js
@@ -12,7 +12,7 @@ export default {
 
   normalizeTransaction(transaction, booked) {
     const transferPrefixes = ['MOB', 'FPS'];
-    const methodRegex = /(Card|WLT)\s\d*/;
+    const methodRegex = /^(Card|WLT)\s\d+/;
 
     const parts = transaction.remittanceInformationUnstructured.split(', ');
 

--- a/src/app-gocardless/banks/virgin_nrnbgb22.js
+++ b/src/app-gocardless/banks/virgin_nrnbgb22.js
@@ -1,0 +1,44 @@
+import Fallback from './integration-bank.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  institutionIds: ['VIRGIN_NRNBGB22'],
+
+  accessValidForDays: 90,
+
+  normalizeAccount(account) {
+    return Fallback.normalizeAccount(account);
+  },
+
+  normalizeTransaction(transaction, booked) {
+    const transferPrefixes = ['MOB', 'FPS'];
+    const methodRegex = /(Card|WLT)\s\d*/;
+
+    const parts = transaction.remittanceInformationUnstructured.split(', ');
+
+    if (transferPrefixes.includes(parts[0])) {
+      // Transfer remittance information begins with either "MOB" or "FPS"
+      // the second field contains the payee and the third contains the
+      // reference
+
+      transaction.creditorName = parts[1];
+      transaction.debtorName = parts[1];
+      transaction.remittanceInformationUnstructured = parts[2];
+    } else if (parts[0].match(methodRegex)) {
+      // The payee is prefixed with the payment method, eg "Card 11, {payee}"
+
+      transaction.creditorName = parts[1];
+      transaction.debtorName = parts[1];
+    }
+
+    return Fallback.normalizeTransaction(transaction, booked);
+  },
+
+  sortTransactions(transactions = []) {
+    return Fallback.sortTransactions(transactions);
+  },
+
+  calculateStartingBalance(sortedTransactions = [], balances = []) {
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
+  },
+};

--- a/src/app-gocardless/banks/virgin_nrnbgb22.js
+++ b/src/app-gocardless/banks/virgin_nrnbgb22.js
@@ -2,13 +2,11 @@ import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['VIRGIN_NRNBGB22'],
 
   accessValidForDays: 90,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   normalizeTransaction(transaction, booked) {
     const transferPrefixes = ['MOB', 'FPS'];
@@ -37,13 +35,5 @@ export default {
     }
 
     return Fallback.normalizeTransaction(transaction, booked);
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/virgin_nrnbgb22.js
+++ b/src/app-gocardless/banks/virgin_nrnbgb22.js
@@ -29,6 +29,11 @@ export default {
 
       transaction.creditorName = parts[1];
       transaction.debtorName = parts[1];
+    } else {
+      // Simple payee name
+
+      transaction.creditorName = transaction.remittanceInformationUnstructured;
+      transaction.debtorName = transaction.remittanceInformationUnstructured;
     }
 
     return Fallback.normalizeTransaction(transaction, booked);

--- a/upcoming-release-notes/360.md
+++ b/upcoming-release-notes/360.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Add bank handler for VIRGIN_NRNBGB22 (Virgin Money) for more accurate payees


### PR DESCRIPTION
This change adds handling in for Virgin Money (VIRGIN_NRNBGB22). They don't return `creditorName` or `debtorName` through GoCardless so all transactions use the unprocessed `remittanceInformationUnstructured` field which contains extra details that make creating rules harder.