### PR TITLE
Refactor GoCardless bank code to avoid duplication

### DIFF
--- a/src/app-gocardless/banks/american-express-aesudef1.js
+++ b/src/app-gocardless/banks/american-express-aesudef1.js
@@ -1,4 +1,6 @@
-import { amountToInteger, sortByBookingDateOrValueDate } from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -30,7 +32,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/american-express-aesudef1.js
+++ b/src/app-gocardless/banks/american-express-aesudef1.js
@@ -4,6 +4,8 @@ import { amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['AMERICAN_EXPRESS_AESUDEF1'],
 
   accessValidForDays: 180,
@@ -29,10 +31,6 @@ export default {
       ...transaction,
       date: transaction.bookingDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/bankinter-bkbkesmm.js
+++ b/src/app-gocardless/banks/bankinter-bkbkesmm.js
@@ -1,18 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
 
-const SORTED_BALANCE_TYPE_LIST = [
-  'closingBooked',
-  'expected',
-  'forwardAvailable',
-  'interimAvailable',
-  'interimBooked',
-  'nonInvoiced',
-  'openingBooked',
-];
+import { printIban } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -46,19 +34,10 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {
-    const currentBalance = balances
-      .filter((item) => SORTED_BALANCE_TYPE_LIST.includes(item.balanceType))
-      .sort(
-        (a, b) =>
-          SORTED_BALANCE_TYPE_LIST.indexOf(a.balanceType) -
-          SORTED_BALANCE_TYPE_LIST.indexOf(b.balanceType),
-      )[0];
-    return sortedTransactions.reduce((total, trans) => {
-      return total - amountToInteger(trans.transactionAmount.amount);
-    }, amountToInteger(currentBalance?.balanceAmount?.amount || 0));
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/bankinter-bkbkesmm.js
+++ b/src/app-gocardless/banks/bankinter-bkbkesmm.js
@@ -4,6 +4,8 @@ import { printIban } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['BANKINTER_BKBKESMM'],
 
   accessValidForDays: 90,
@@ -31,13 +33,5 @@ export default {
           .replaceAll(';', ' '),
       date: transaction.bookingDate || transaction.valueDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/belfius_gkccbebb.js
+++ b/src/app-gocardless/banks/belfius_gkccbebb.js
@@ -2,13 +2,11 @@ import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['BELFIUS_GKCCBEBB'],
 
   accessValidForDays: 180,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   // The problem is that we have transaction with duplicated transaction ids.
   // This is not expected and the nordigen api has a work-around for some backs
@@ -19,13 +17,5 @@ export default {
       transactionId: transaction.internalTransactionId,
       date: transaction.bookingDate || transaction.valueDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -2,6 +2,8 @@ import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: [
     'FINTRO_BE_GEBABEBB',
     'HELLO_BE_GEBABEBB',
@@ -9,10 +11,6 @@ export default {
   ],
 
   accessValidForDays: 180,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   /** BNP_BE_GEBABEBB provides a lot of useful information via the 'additionalField'
    *  There does not seem to be a specification of this field, but the following information is contained in its subfields:
@@ -73,13 +71,5 @@ export default {
       creditorName: creditorName,
       date: transaction.valueDate || transaction.bookingDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/bnp-be-gebabebb.js
+++ b/src/app-gocardless/banks/bnp-be-gebabebb.js
@@ -1,18 +1,4 @@
-import {
-  sortByBookingDateOrValueDate,
-  amountToInteger,
-  printIban,
-} from '../utils.js';
-
-const SORTED_BALANCE_TYPE_LIST = [
-  'closingBooked',
-  'expected',
-  'forwardAvailable',
-  'interimAvailable',
-  'interimBooked',
-  'nonInvoiced',
-  'openingBooked',
-];
+import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -25,17 +11,7 @@ export default {
   accessValidForDays: 180,
 
   normalizeAccount(account) {
-    return {
-      account_id: account.id,
-      institution: account.institution,
-      mask: (account?.iban || '0000').slice(-4),
-      iban: account?.iban || null,
-      name: [account.name, printIban(account), account.currency]
-        .filter(Boolean)
-        .join(' '),
-      official_name: `integration-${account.institution_id}`,
-      type: 'checking',
-    };
+    return Fallback.normalizeAccount(account);
   },
 
   /** BNP_BE_GEBABEBB provides a lot of useful information via the 'additionalField'
@@ -100,19 +76,10 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {
-    const currentBalance = balances
-      .filter((item) => SORTED_BALANCE_TYPE_LIST.includes(item.balanceType))
-      .sort(
-        (a, b) =>
-          SORTED_BALANCE_TYPE_LIST.indexOf(a.balanceType) -
-          SORTED_BALANCE_TYPE_LIST.indexOf(b.balanceType),
-      )[0];
-    return sortedTransactions.reduce((total, trans) => {
-      return total - amountToInteger(trans.transactionAmount.amount);
-    }, amountToInteger(currentBalance?.balanceAmount?.amount || 0));
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/danskebank-dabno22.js
+++ b/src/app-gocardless/banks/danskebank-dabno22.js
@@ -4,6 +4,8 @@ import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['DANSKEBANK_DABANO22'],
 
   accessValidForDays: 180,
@@ -42,10 +44,6 @@ export default {
       ...transaction,
       date: transaction.bookingDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {

--- a/src/app-gocardless/banks/danskebank-dabno22.js
+++ b/src/app-gocardless/banks/danskebank-dabno22.js
@@ -1,8 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -47,7 +45,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {

--- a/src/app-gocardless/banks/ing-ingddeff.js
+++ b/src/app-gocardless/banks/ing-ingddeff.js
@@ -1,7 +1,11 @@
+import Fallback from './integration-bank.js';
+
 import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['ING_INGDDEFF'],
 
   accessValidForDays: 180,

--- a/src/app-gocardless/banks/ing-pl-ingbplpw.js
+++ b/src/app-gocardless/banks/ing-pl-ingbplpw.js
@@ -1,7 +1,11 @@
+import Fallback from './integration-bank.js';
+
 import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['ING_PL_INGBPLPW'],
 
   accessValidForDays: 180,

--- a/src/app-gocardless/banks/mbank-retail-brexplpw.js
+++ b/src/app-gocardless/banks/mbank-retail-brexplpw.js
@@ -1,7 +1,11 @@
+import Fallback from './integration-bank.js';
+
 import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['MBANK_RETAIL_BREXPLPW'],
 
   accessValidForDays: 180,

--- a/src/app-gocardless/banks/norwegian-xx-norwnok1.js
+++ b/src/app-gocardless/banks/norwegian-xx-norwnok1.js
@@ -1,8 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -73,7 +71,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/norwegian-xx-norwnok1.js
+++ b/src/app-gocardless/banks/norwegian-xx-norwnok1.js
@@ -4,6 +4,8 @@ import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: [
     'NORWEGIAN_NO_NORWNOK1',
     'NORWEGIAN_SE_NORWNOK1',
@@ -68,10 +70,6 @@ export default {
     }
 
     return null;
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/sandboxfinance-sfin0000.js
+++ b/src/app-gocardless/banks/sandboxfinance-sfin0000.js
@@ -4,6 +4,8 @@ import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['SANDBOXFINANCE_SFIN0000'],
 
   accessValidForDays: 90,
@@ -33,10 +35,6 @@ export default {
       ...transaction,
       date: transaction.bookingDate || transaction.valueDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/sandboxfinance-sfin0000.js
+++ b/src/app-gocardless/banks/sandboxfinance-sfin0000.js
@@ -1,8 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -38,7 +36,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/seb-kort-bank-ab.js
+++ b/src/app-gocardless/banks/seb-kort-bank-ab.js
@@ -1,8 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -40,7 +38,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/seb-kort-bank-ab.js
+++ b/src/app-gocardless/banks/seb-kort-bank-ab.js
@@ -4,6 +4,8 @@ import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['SEB_KORT_AB_NO_SKHSFI21', 'SEB_KORT_AB_SE_SKHSFI21'],
 
   accessValidForDays: 180,
@@ -35,10 +37,6 @@ export default {
         currency: transaction.transactionAmount.currency,
       },
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/seb-privat.js
+++ b/src/app-gocardless/banks/seb-privat.js
@@ -1,9 +1,7 @@
+import Fallback from './integration-bank.js';
+
 import * as d from 'date-fns';
-import {
-  sortByBookingDateOrValueDate,
-  amountToInteger,
-  printIban,
-} from '../utils.js';
+import { amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -12,17 +10,7 @@ export default {
   accessValidForDays: 180,
 
   normalizeAccount(account) {
-    return {
-      account_id: account.id,
-      institution: account.institution,
-      mask: (account?.iban || '0000').slice(-4),
-      iban: account?.iban || null,
-      name: [account.name, printIban(account), account.currency]
-        .filter(Boolean)
-        .join(' '),
-      official_name: `integration-${account.institution_id}`,
-      type: 'checking',
-    };
+    return Fallback.normalizeAccount(account);
   },
 
   normalizeTransaction(transaction, _booked) {
@@ -46,7 +34,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {

--- a/src/app-gocardless/banks/seb-privat.js
+++ b/src/app-gocardless/banks/seb-privat.js
@@ -5,13 +5,11 @@ import { amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['SEB_ESSESESS_PRIVATE'],
 
   accessValidForDays: 180,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   normalizeTransaction(transaction, _booked) {
     const date =
@@ -31,10 +29,6 @@ export default {
       creditorName: transaction.additionalInformation,
       date: d.format(d.parseISO(date), 'yyyy-MM-dd'),
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {

--- a/src/app-gocardless/banks/sparnord-spnodk22.js
+++ b/src/app-gocardless/banks/sparnord-spnodk22.js
@@ -2,6 +2,8 @@ import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: [
     'SPARNORD_SPNODK22',
     'LAGERNES_BANK_LAPNDKK1',
@@ -9,10 +11,6 @@ export default {
   ],
 
   accessValidForDays: 180,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   /**
    * Banks on the BEC backend only give information regarding the transaction in additionalInformation
@@ -23,13 +21,5 @@ export default {
       date: transaction.bookingDate,
       remittanceInformationUnstructured: transaction.additionalInformation,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/sparnord-spnodk22.js
+++ b/src/app-gocardless/banks/sparnord-spnodk22.js
@@ -1,18 +1,4 @@
-import {
-  sortByBookingDateOrValueDate,
-  amountToInteger,
-  printIban,
-} from '../utils.js';
-
-const SORTED_BALANCE_TYPE_LIST = [
-  'closingBooked',
-  'expected',
-  'forwardAvailable',
-  'interimAvailable',
-  'interimBooked',
-  'nonInvoiced',
-  'openingBooked',
-];
+import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -25,17 +11,7 @@ export default {
   accessValidForDays: 180,
 
   normalizeAccount(account) {
-    return {
-      account_id: account.id,
-      institution: account.institution,
-      mask: (account?.iban || '0000').slice(-4),
-      iban: account?.iban || null,
-      name: [account.name, printIban(account), account.currency]
-        .filter(Boolean)
-        .join(' '),
-      official_name: `integration-${account.institution_id}`,
-      type: 'checking',
-    };
+    return Fallback.normalizeAccount(account);
   },
 
   /**
@@ -50,19 +26,10 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {
-    const currentBalance = balances
-      .filter((item) => SORTED_BALANCE_TYPE_LIST.includes(item.balanceType))
-      .sort(
-        (a, b) =>
-          SORTED_BALANCE_TYPE_LIST.indexOf(a.balanceType) -
-          SORTED_BALANCE_TYPE_LIST.indexOf(b.balanceType),
-      )[0];
-    return sortedTransactions.reduce((total, trans) => {
-      return total - amountToInteger(trans.transactionAmount.amount);
-    }, amountToInteger(currentBalance?.balanceAmount?.amount || 0));
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/spk-karlsruhe-karsde66.js
+++ b/src/app-gocardless/banks/spk-karlsruhe-karsde66.js
@@ -4,6 +4,8 @@ import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['SPK_KARLSRUHE_KARSDE66XXX'],
 
   accessValidForDays: 90,
@@ -70,10 +72,6 @@ export default {
       remittanceInformationUnstructured: remittanceInformationUnstructured,
       date: transaction.bookingDate || transaction.valueDate,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/spk-karlsruhe-karsde66.js
+++ b/src/app-gocardless/banks/spk-karlsruhe-karsde66.js
@@ -1,8 +1,6 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
+import Fallback from './integration-bank.js';
+
+import { printIban, amountToInteger } from '../utils.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -75,7 +73,7 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   /**

--- a/src/app-gocardless/banks/spk-marburg-biedenkopf-heladef1mar.js
+++ b/src/app-gocardless/banks/spk-marburg-biedenkopf-heladef1mar.js
@@ -1,19 +1,7 @@
-import {
-  printIban,
-  amountToInteger,
-  sortByBookingDateOrValueDate,
-} from '../utils.js';
-import d from 'date-fns';
+import Fallback from './integration-bank.js';
 
-const SORTED_BALANCE_TYPE_LIST = [
-  'closingBooked',
-  'expected',
-  'forwardAvailable',
-  'interimAvailable',
-  'interimBooked',
-  'nonInvoiced',
-  'openingBooked',
-];
+import { printIban } from '../utils.js';
+import d from 'date-fns';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -70,20 +58,10 @@ export default {
   },
 
   sortTransactions(transactions = []) {
-    return sortByBookingDateOrValueDate(transactions);
+    return Fallback.sortTransactions(transactions);
   },
 
   calculateStartingBalance(sortedTransactions = [], balances = []) {
-    const currentBalance = balances
-      .filter((item) => SORTED_BALANCE_TYPE_LIST.includes(item.balanceType))
-      .sort(
-        (a, b) =>
-          SORTED_BALANCE_TYPE_LIST.indexOf(a.balanceType) -
-          SORTED_BALANCE_TYPE_LIST.indexOf(b.balanceType),
-      )[0];
-
-    return sortedTransactions.reduce((total, trans) => {
-      return total - amountToInteger(trans.transactionAmount.amount);
-    }, amountToInteger(currentBalance?.balanceAmount?.amount || 0));
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/spk-marburg-biedenkopf-heladef1mar.js
+++ b/src/app-gocardless/banks/spk-marburg-biedenkopf-heladef1mar.js
@@ -5,6 +5,8 @@ import d from 'date-fns';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['SPK_MARBURG_BIEDENKOPF_HELADEF1MAR'],
 
   accessValidForDays: 180,
@@ -55,13 +57,5 @@ export default {
       date: d.format(d.parseISO(date), 'yyyy-MM-dd'),
       remittanceInformationUnstructured: remittanceInformationUnstructured,
     };
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/upcoming-release-notes/362.md
+++ b/upcoming-release-notes/362.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [psybers]
+---
+
+Refactor GoCardless bank code to avoid duplication.


### PR DESCRIPTION
The custom bank code typically copies/pastes an existing bank and then modifies it.  So there is a lot of duplicated code.  This is a first pass at refactoring to reuse the fallback code from `integration-bank.js` and avoid duplication.

NOTE: I do not have GoCardless and can not test for breaking changes.  The existing test suite still works but is quite lacking in coverage of these files.