### PR TITLE
Ignore coverage folder in the coverage report.

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -7,7 +7,7 @@
   "testEnvironment": "node",
   "collectCoverage": true,
   "collectCoverageFrom": ["**/*.{js,ts,tsx}"],
-  "coveragePathIgnorePatterns": ["dist", "/node_modules/", "/build/"],
+  "coveragePathIgnorePatterns": ["dist", "/node_modules/", "/build/", "/coverage/"],
   "coverageReporters": ["html", "lcov", "text", "text-summary"],
   "resetMocks": true,
   "restoreMocks": true

--- a/upcoming-release-notes/366.md
+++ b/upcoming-release-notes/366.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [psybers]
+---
+
+Ignore coverage folder in the coverage report.


### PR DESCRIPTION
Currently, the generated `coverage/` folder is analyzed for coverage.  This ignores it.