### PR TITLE
Add bank handler for `NATIONWIDE_NAIAGB21` (Nationwide)

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -8,6 +8,7 @@ import IngIngddeff from './banks/ing-ingddeff.js';
 import IngPlIngbplpw from './banks/ing-pl-ingbplpw.js';
 import IntegrationBank from './banks/integration-bank.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
+import NationwideNaiaGB21 from './banks/nationwide-naiagb21.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
 import SEBKortBankAB from './banks/seb-kort-bank-ab.js';
 import SEBPrivat from './banks/seb-privat.js';
@@ -26,6 +27,7 @@ export const banks = [
   IngIngddeff,
   IngPlIngbplpw,
   MbankRetailBrexplpw,
+  NationwideNaiaGB21,
   NorwegianXxNorwnok1,
   SEBKortBankAB,
   SEBPrivat,

--- a/src/app-gocardless/banks/nationwide-naiagb21.js
+++ b/src/app-gocardless/banks/nationwide-naiagb21.js
@@ -15,7 +15,7 @@ export default {
     // and the transactionID from Nationwide changes when a transaction is
     // booked
     if (!booked) {
-      const d = new Date(transaction.bookingDate)
+      const d = new Date(transaction.bookingDate);
       d.setDate(d.getDate() - 8);
 
       const useDate = new Date(Math.min(d.getTime(), new Date().getTime()));
@@ -27,8 +27,11 @@ export default {
     // that are malformed and can even change after import. This will ignore
     // these ids and unset them. When a correct ID is returned then it will
     // update via the deduplication logic
-    const debitCreditRegex = /^00(DEB|CRED)IT.+$/
-    if (transaction.transactionId?.match(debitCreditRegex) || transaction.transactionId?.length !== 40) {
+    const debitCreditRegex = /^00(DEB|CRED)IT.+$/;
+    if (
+      transaction.transactionId?.match(debitCreditRegex) ||
+      transaction.transactionId?.length !== 40
+    ) {
       transaction.transactionId = null;
     }
 

--- a/src/app-gocardless/banks/nationwide-naiagb21.js
+++ b/src/app-gocardless/banks/nationwide-naiagb21.js
@@ -23,14 +23,21 @@ export default {
       transaction.bookingDate = useDate.toISOString().slice(0, 10);
     }
 
+    console.log(transaction);
+
     // Nationwide also occasionally returns erroneous transaction_ids
     // that are malformed and can even change after import. This will ignore
     // these ids and unset them. When a correct ID is returned then it will
     // update via the deduplication logic
     const debitCreditRegex = /^00(DEB|CRED)IT.+$/;
+    const validLengths = [
+      40, // Nationwide credit cards
+      32, // Nationwide current accounts
+    ];
+
     if (
       transaction.transactionId?.match(debitCreditRegex) ||
-      transaction.transactionId?.length !== 40
+      !validLengths.includes(transaction.transactionId?.length)
     ) {
       transaction.transactionId = null;
     }

--- a/src/app-gocardless/banks/nationwide-naiagb21.js
+++ b/src/app-gocardless/banks/nationwide-naiagb21.js
@@ -2,13 +2,11 @@ import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
+  ...Fallback,
+
   institutionIds: ['NATIONWIDE_NAIAGB21'],
 
   accessValidForDays: 90,
-
-  normalizeAccount(account) {
-    return Fallback.normalizeAccount(account);
-  },
 
   normalizeTransaction(transaction, booked) {
     // Nationwide returns pending transactions with a date representing
@@ -35,13 +33,5 @@ export default {
     }
 
     return Fallback.normalizeTransaction(transaction, booked);
-  },
-
-  sortTransactions(transactions = []) {
-    return Fallback.sortTransactions(transactions);
-  },
-
-  calculateStartingBalance(sortedTransactions = [], balances = []) {
-    return Fallback.calculateStartingBalance(sortedTransactions, balances);
   },
 };

--- a/src/app-gocardless/banks/nationwide-naiagb21.js
+++ b/src/app-gocardless/banks/nationwide-naiagb21.js
@@ -1,0 +1,47 @@
+import Fallback from './integration-bank.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  institutionIds: ['NATIONWIDE_NAIAGB21'],
+
+  accessValidForDays: 90,
+
+  normalizeAccount(account) {
+    return Fallback.normalizeAccount(account);
+  },
+
+  normalizeTransaction(transaction, booked) {
+    // Nationwide returns pending transactions with a date representing
+    // the latest a transaction could be booked. This stops actual's
+    // deduplication logic from working as it only checks 7 days ahead/behind
+    // and the transactionID from Nationwide changes when a transaction is
+    // booked
+    if (!booked) {
+      const d = new Date(transaction.bookingDate)
+      d.setDate(d.getDate() - 8);
+
+      const useDate = new Date(Math.min(d.getTime(), new Date().getTime()));
+
+      transaction.bookingDate = useDate.toISOString().slice(0, 10);
+    }
+
+    // Nationwide also occasionally returns erroneous transaction_ids
+    // that are malformed and can even change after import. This will ignore
+    // these ids and unset them. When a correct ID is returned then it will
+    // update via the deduplication logic
+    const debitCreditRegex = /^00(DEB|CRED)IT.+$/
+    if (transaction.transactionId?.match(debitCreditRegex) || transaction.transactionId?.length !== 40) {
+      transaction.transactionId = null;
+    }
+
+    return Fallback.normalizeTransaction(transaction, booked);
+  },
+
+  sortTransactions(transactions = []) {
+    return Fallback.sortTransactions(transactions);
+  },
+
+  calculateStartingBalance(sortedTransactions = [], balances = []) {
+    return Fallback.calculateStartingBalance(sortedTransactions, balances);
+  },
+};

--- a/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
+++ b/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
@@ -36,14 +36,16 @@ describe('Nationwide', () => {
         false,
       );
 
-      expect((new Date(normalizedTransaction.date)).getTime()).toBeLessThan(d.getTime());
+      expect(new Date(normalizedTransaction.date).getTime()).toBeLessThan(
+        d.getTime(),
+      );
     });
 
     it('keeps transactionId if in the correct format', () => {
-      const transactionId = "a896729bb8b30b5ca862fe70bd5967185e2b5d3a";
+      const transactionId = 'a896729bb8b30b5ca862fe70bd5967185e2b5d3a';
       const transaction = {
         bookingDate: '2024-01-01T00:00:00Z',
-	transactionId,
+        transactionId,
         transactionAmount: mockTransactionAmount,
       };
 
@@ -58,7 +60,7 @@ describe('Nationwide', () => {
     it('unsets transactionId if not 40 chars', () => {
       const transaction = {
         bookingDate: '2024-01-01T00:00:00Z',
-	transactionId: '0123456789',
+        transactionId: '0123456789',
         transactionAmount: mockTransactionAmount,
       };
 
@@ -73,7 +75,7 @@ describe('Nationwide', () => {
     it('unsets transactionId if debit placeholder found', () => {
       const transaction = {
         bookingDate: '2024-01-01T00:00:00Z',
-	transactionId: '00DEBIT202401010000000000-1000SUPERMARKET',
+        transactionId: '00DEBIT202401010000000000-1000SUPERMARKET',
         transactionAmount: mockTransactionAmount,
       };
 
@@ -88,7 +90,7 @@ describe('Nationwide', () => {
     it('unsets transactionId if credit placeholder found', () => {
       const transaction = {
         bookingDate: '2024-01-01T00:00:00Z',
-	transactionId: '00CREDIT202401010000000000-1000SUPERMARKET',
+        transactionId: '00CREDIT202401010000000000-1000SUPERMARKET',
         transactionAmount: mockTransactionAmount,
       };
 

--- a/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
+++ b/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
@@ -57,7 +57,7 @@ describe('Nationwide', () => {
       expect(normalizedTransaction.transactionId).toBe(transactionId);
     });
 
-    it('unsets transactionId if not 40 chars', () => {
+    it('unsets transactionId if not valid length', () => {
       const transaction = {
         bookingDate: '2024-01-01T00:00:00Z',
         transactionId: '0123456789',

--- a/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
+++ b/src/app-gocardless/banks/tests/nationwide-naiagb21.spec.js
@@ -1,0 +1,103 @@
+import Nationwide from '../nationwide-naiagb21.js';
+import { mockTransactionAmount } from '../../services/tests/fixtures.js';
+
+describe('Nationwide', () => {
+  describe('#normalizeTransaction', () => {
+    it('retains date for booked transaction', () => {
+      const d = new Date();
+      d.setDate(d.getDate() - 7);
+
+      const date = d.toISOString().split('T')[0];
+
+      const transaction = {
+        bookingDate: date,
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        true,
+      );
+
+      expect(normalizedTransaction.date).toEqual(date);
+    });
+
+    it('fixes date for pending transactions', () => {
+      const d = new Date();
+      const date = d.toISOString().split('T')[0];
+
+      const transaction = {
+        bookingDate: date,
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect((new Date(normalizedTransaction.date)).getTime()).toBeLessThan(d.getTime());
+    });
+
+    it('keeps transactionId if in the correct format', () => {
+      const transactionId = "a896729bb8b30b5ca862fe70bd5967185e2b5d3a";
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+	transactionId,
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect(normalizedTransaction.transactionId).toBe(transactionId);
+    });
+
+    it('unsets transactionId if not 40 chars', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+	transactionId: '0123456789',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect(normalizedTransaction.transactionId).toBeNull();
+    });
+
+    it('unsets transactionId if debit placeholder found', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+	transactionId: '00DEBIT202401010000000000-1000SUPERMARKET',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect(normalizedTransaction.transactionId).toBeNull();
+    });
+
+    it('unsets transactionId if credit placeholder found', () => {
+      const transaction = {
+        bookingDate: '2024-01-01T00:00:00Z',
+	transactionId: '00CREDIT202401010000000000-1000SUPERMARKET',
+        transactionAmount: mockTransactionAmount,
+      };
+
+      const normalizedTransaction = Nationwide.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect(normalizedTransaction.transactionId).toBeNull();
+    });
+  });
+});

--- a/upcoming-release-notes/372.md
+++ b/upcoming-release-notes/372.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Add bank handler for NATIONWIDE_NAIAGB21 (Nationwide) for more accurate dates and to fix duplicate transaction issues


### PR DESCRIPTION
Nationwide returns pending transactions with a date representing the latest a transaction could be booked. This stops actual's deduplication logic from working as it only checks 7 days ahead/behind and the transactionID from Nationwide changes when a transaction is booked.

There is also a seperate issue where they sometimes return invalid transactionIds that can change in the future and with the merge of actualbudget/actual#2770 prevents deduplication with the original transaction.

I've reported this to gocardless, they've taken it to nationwide but unfortunately I received this back this morning.
![image](https://github.com/actualbudget/actual-server/assets/81489167/1a99e3dc-a8e1-44f8-a12e-80ffe806c41c)

An image below showing the issue caused by the transaction ID (these are the same transaction)
![image](https://github.com/actualbudget/actual-server/assets/81489167/e729f76b-e8a8-4b79-9c94-122c63e2546d)

This has been discussed in Discord <#1148889147801604096> where it was suggested I upstream this patch which I've been using in my own fork for a while.