### PR TITLE
remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   actual_server:
     image: docker.io/actualbudget/actual-server:latest


### PR DESCRIPTION
version for docker compose files is obsolete, it has no practical functionality, but causes WARN on command line. previously it was used to determine the type of dockerfile, and saying " "version" is obsolete" might be confusing to non-technical users trying to get actual running via docker.

fixes #387 