### PR TITLE
Update SEB Credit Card adapter to include SEB Card Accounts

### DIFF
--- a/src/app-gocardless/banks/seb-kort-bank-ab.js
+++ b/src/app-gocardless/banks/seb-kort-bank-ab.js
@@ -6,7 +6,11 @@ import { printIban, amountToInteger } from '../utils.js';
 export default {
   ...Fallback,
 
-  institutionIds: ['SEB_KORT_AB_NO_SKHSFI21', 'SEB_KORT_AB_SE_SKHSFI21'],
+  institutionIds: [
+    'SEB_KORT_AB_NO_SKHSFI21',
+    'SEB_KORT_AB_SE_SKHSFI21',
+    'SEB_CARD_ESSESESS',
+  ],
 
   accessValidForDays: 180,
 

--- a/upcoming-release-notes/391.md
+++ b/upcoming-release-notes/391.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [craigmdennis]
+---
+
+Add SEB Card Accounts to bank adapter to flip payment and deposit when importing


### PR DESCRIPTION
Relates to #261 
Add SEB Card Accounts institution ID to correctly import purchases as payments instead of deposits.

### Before
![Arc 2024-07-08 at 10 56 37@2x](https://github.com/actualbudget/actual-server/assets/725067/f51246fb-f90c-4086-9184-19b8dd6d8fce)

### After
![Arc 2024-07-08 at 10 58 40@2x](https://github.com/actualbudget/actual-server/assets/725067/176bc782-e221-4ca7-ab6c-ab7d33d72921)
