### PR TITLE
Add gocardless support for easybank (Austria)

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -18,6 +18,7 @@ import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
 import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
 import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
+import EasybankBawaatww from './banks/easybank-bawaatww.js';
 
 export const banks = [
   AbancaCaglesmm,
@@ -26,6 +27,7 @@ export const banks = [
   Belfius,
   BnpBeGebabebb,
   DanskeBankDabNO22,
+  EasybankBawaatww,
   Fortuneo,
   IngIngddeff,
   IngPlIngbplpw,

--- a/src/app-gocardless/banks/bank.interface.ts
+++ b/src/app-gocardless/banks/bank.interface.ts
@@ -27,7 +27,7 @@ export interface IBank {
   normalizeTransaction: (
     transaction: Transaction,
     booked: boolean,
-  ) => (Transaction & { date?: string }) | null;
+  ) => (Transaction & { date?: string; payeeName: string }) | null;
 
   /**
    * Function sorts an array of transactions from newest to oldest

--- a/src/app-gocardless/banks/easybank-bawaatww.js
+++ b/src/app-gocardless/banks/easybank-bawaatww.js
@@ -1,0 +1,61 @@
+import Fallback from './integration-bank.js';
+
+import { formatPayeeName } from '../../util/payee-name.js';
+import d from 'date-fns';
+import { title } from '../../util/title/index.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  ...Fallback,
+
+  institutionIds: ['EASYBANK_BAWAATWW'],
+
+  accessValidForDays: 180,
+
+  // If date is same, sort by transactionId
+  sortTransactions: (transactions = []) =>
+    transactions.sort((a, b) => {
+      const diff =
+        +new Date(b.valueDate || b.bookingDate) -
+        +new Date(a.valueDate || a.bookingDate);
+      if (diff != 0) return diff;
+      return parseInt(b.transactionId) - parseInt(a.transactionId);
+    }),
+
+  normalizeTransaction(transaction, _booked) {
+    const date = transaction.bookingDate || transaction.valueDate;
+
+    // If we couldn't find a valid date field we filter out this transaction
+    // and hope that we will import it again once the bank has processed the
+    // transaction further.
+    if (!date) {
+      return null;
+    }
+
+    let payeeName = formatPayeeName(transaction);
+    if (!payeeName) payeeName = extractPayeeName(transaction);
+
+    return {
+      ...transaction,
+      payeeName: payeeName,
+      date: d.format(d.parseISO(date), 'yyyy-MM-dd'),
+    };
+  },
+};
+
+/**
+ * Extracts the payee name from the remittanceInformationStructured
+ * @param {import('../gocardless-node.types.js').Transaction} transaction
+ */
+function extractPayeeName(transaction) {
+  const structured = transaction.remittanceInformationStructured;
+  // The payee name is betweeen the transaction timestamp (11.07. 11:36) and the location, that starts with \\
+  const regex = /\d{2}\.\d{2}\. \d{2}:\d{2}(.*)\\\\/;
+  const matches = structured.match(regex);
+  if (matches && matches.length > 1 && matches[1]) {
+    return title(matches[1]);
+  } else {
+    // As a fallback if still no payee is found, the whole information is used
+    return structured;
+  }
+}

--- a/src/app-gocardless/banks/tests/easybank-bawaatww.spec.js
+++ b/src/app-gocardless/banks/tests/easybank-bawaatww.spec.js
@@ -1,0 +1,54 @@
+import EasybankBawaatww from '../easybank-bawaatww.js';
+import { mockTransactionAmount } from '../../services/tests/fixtures.js';
+
+describe('easybank', () => {
+  describe('#normalizeTransaction', () => {
+    it('returns the expected payeeName from a transaction with a set creditorName', () => {
+      const transaction = {
+        creditorName: 'Some Payee Name',
+        transactionAmount: mockTransactionAmount,
+        bookingDate: '2024-01-01',
+        creditorAccount: 'AT611904300234573201',
+      };
+
+      const normalizedTransaction = EasybankBawaatww.normalizeTransaction(
+        transaction,
+        true,
+      );
+
+      expect(normalizedTransaction.payeeName).toEqual('Some Payee Name');
+    });
+
+    it('returns the expected payeeName from a transaction with payee name inside structuredInformation', () => {
+      const transaction = {
+        payeeName: '',
+        transactionAmount: mockTransactionAmount,
+        remittanceInformationStructured:
+          'Bezahlung Karte MC/000001234POS 1234 K001 12.12. 23:59SOME PAYEE NAME\\\\LOCATION\\1',
+        bookingDate: '2023-12-31',
+      };
+      const normalizedTransaction = EasybankBawaatww.normalizeTransaction(
+        transaction,
+        true,
+      );
+      expect(normalizedTransaction.payeeName).toEqual('Some Payee Name');
+    });
+
+    it('returns the full structured information as payeeName from a transaction with no payee name', () => {
+      const transaction = {
+        payeeName: 'some-payee-name',
+        transactionAmount: mockTransactionAmount,
+        remittanceInformationStructured:
+          'Auszahlung Karte MC/000001234AUTOMAT 00012345 K001 31.12. 23:59',
+        bookingDate: '2023-12-31',
+      };
+      const normalizedTransaction = EasybankBawaatww.normalizeTransaction(
+        transaction,
+        true,
+      );
+      expect(normalizedTransaction.payeeName).toEqual(
+        'Auszahlung Karte MC/000001234AUTOMAT 00012345 K001 31.12. 23:59',
+      );
+    });
+  });
+});

--- a/src/app-gocardless/banks/tests/easybank-bawaatww.spec.js
+++ b/src/app-gocardless/banks/tests/easybank-bawaatww.spec.js
@@ -36,7 +36,7 @@ describe('easybank', () => {
 
     it('returns the full structured information as payeeName from a transaction with no payee name', () => {
       const transaction = {
-        payeeName: 'some-payee-name',
+        payeeName: '',
         transactionAmount: mockTransactionAmount,
         remittanceInformationStructured:
           'Auszahlung Karte MC/000001234AUTOMAT 00012345 K001 31.12. 23:59',

--- a/upcoming-release-notes/396.md
+++ b/upcoming-release-notes/396.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [neuos]
+---
+
+Add easybank GoCardless Integration


### PR DESCRIPTION
This enhances the parsing of payeeName for the Austrian bank easybank (BAWAATWW) as it is often left blank with the default implementation.