### PR TITLE
[WIP] Fix SimpleFIN blank payee introduced in #353

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -2,7 +2,6 @@ import express from 'express';
 import { inspect } from 'util';
 import https from 'https';
 import { SecretName, secretsService } from '../services/secrets-service.js';
-import { formatPayeeName } from '../util/payee-name.js';
 import { handleError } from '../app-gocardless/util/handle-error.js';
 
 const app = express();
@@ -145,7 +144,7 @@ app.post(
 
         newTrans.date = new Date(dateToUse * 1000).toISOString().split('T')[0];
         newTrans.debtorName = trans.payee;
-        newTrans.payeeName = formatPayeeName(trans);
+        newTrans.payeeName = trans.payee;
         //newTrans.debtorAccount = don't have compared to GoCardless
         newTrans.remittanceInformationUnstructured = trans.description;
         newTrans.transactionAmount = { amount: trans.amount, currency: 'USD' };


### PR DESCRIPTION
Remove formatPayeeName function from SimpleFIN server side, since SimpleFIN transaction objects aren't compatible. ( trans.payee is the preferred method).

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
