### PR TITLE
fix date calculation in Nationwide bank handler

### DIFF
--- a/src/app-gocardless/banks/nationwide-naiagb21.js
+++ b/src/app-gocardless/banks/nationwide-naiagb21.js
@@ -9,17 +9,18 @@ export default {
   accessValidForDays: 90,
 
   normalizeTransaction(transaction, booked) {
-    // Nationwide returns pending transactions with a date representing
-    // the latest a transaction could be booked. This stops actual's
-    // deduplication logic from working as it only checks 7 days ahead/behind
-    // and the transactionID from Nationwide changes when a transaction is
-    // booked
+    // Nationwide can sometimes return pending transactions with a date
+    // representing the latest a transaction could be booked. This stops
+    // actual's deduplication logic from working as it only checks 7 days
+    // ahead/behind and the transactionID from Nationwide changes when a
+    // transaction is booked
     if (!booked) {
-      const d = new Date(transaction.bookingDate);
-      d.setDate(d.getDate() - 8);
-
-      const useDate = new Date(Math.min(d.getTime(), new Date().getTime()));
-
+      const useDate = new Date(
+        Math.min(
+          new Date(transaction.bookingDate).getTime(),
+          new Date().getTime(),
+        ),
+      );
       transaction.bookingDate = useDate.toISOString().slice(0, 10);
     }
 

--- a/upcoming-release-notes/406.md
+++ b/upcoming-release-notes/406.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix date calculation in Nationwide bank handler


### PR DESCRIPTION
People were hitting bugs in this handler in relation to the 8 day adjustment. The better approach to this is to just clamp the max date to today's.