### PR TITLE
Stop server crashing when SimpleFIN is down.

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -60,7 +60,7 @@ app.post(
         },
       });
     } catch (e) {
-      serverDown(res);
+      serverDown(e, res);
       return;
     }
   }),
@@ -82,7 +82,7 @@ app.post(
     try {
       results = await getTransactions(accessKey, new Date(startDate));
     } catch (e) {
-      serverDown(res);
+      serverDown(e, res);
       return;
     }
 
@@ -205,7 +205,8 @@ function invalidToken(res) {
   });
 }
 
-function serverDown(res) {
+function serverDown(e, res) {
+  console.log(e);
   res.send({
     status: 'ok',
     data: {

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -50,14 +50,19 @@ app.post(
     const startDate = new Date(now.getFullYear(), now.getMonth(), 1);
     const endDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
-    const accounts = await getAccounts(accessKey, startDate, endDate);
+    try {
+      const accounts = await getAccounts(accessKey, startDate, endDate);
 
-    res.send({
-      status: 'ok',
-      data: {
-        accounts: accounts.accounts,
-      },
-    });
+      res.send({
+        status: 'ok',
+        data: {
+          accounts: accounts.accounts,
+        },
+      });
+    } catch (e) {
+      serverDown(res);
+      return;
+    }
   }),
 );
 
@@ -73,9 +78,15 @@ app.post(
       return;
     }
 
+    let results;
     try {
-      const results = await getTransactions(accessKey, new Date(startDate));
+      results = await getTransactions(accessKey, new Date(startDate));
+    } catch (e) {
+      serverDown(res);
+      return;
+    }
 
+    try {
       const account = results.accounts.find((a) => a.id === accountId);
 
       const needsAttention = results.errors.find(
@@ -190,6 +201,19 @@ function invalidToken(res) {
       status: 'rejected',
       reason:
         'Invalid SimpleFIN access token.  Reset the token and re-link any broken accounts.',
+    },
+  });
+}
+
+function serverDown(res) {
+  res.send({
+    status: 'ok',
+    data: {
+      error_type: 'SERVER_DOWN',
+      error_code: 'SERVER_DOWN',
+      status: 'rejected',
+      reason:
+        'There was an error communciating with SimpleFIN.',
     },
   });
 }

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -212,8 +212,7 @@ function serverDown(res) {
       error_type: 'SERVER_DOWN',
       error_code: 'SERVER_DOWN',
       status: 'rejected',
-      reason:
-        'There was an error communciating with SimpleFIN.',
+      reason: 'There was an error communciating with SimpleFIN.',
     },
   });
 }

--- a/upcoming-release-notes/410.md
+++ b/upcoming-release-notes/410.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [psybers]
+---
+
+Stop server crashing when SimpleFIN is down.


### PR DESCRIPTION
When SimpelFIN is down, we get 502 errors.  The JSON tries to parse, and fails.  The last commit simply wrapped that in a reject, but then nothing ever catches that rejected promise.  This catches them and sends a failure response code, and then returns (and avoids the server crashing).