### PR TITLE
Show better error if SimpleFIN account cant be found.

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -87,18 +87,23 @@ app.post(
     }
 
     try {
-      const account = !results?.accounts || results.accounts.find((a) => a.id === accountId);
+      const account =
+        !results?.accounts || results.accounts.find((a) => a.id === accountId);
       if (!account) {
-        console.log(`The account "${accountId}" was not found. Here were the accounts returned:`);
-        if (results?.accounts) results.accounts.forEach((a) => console.log(`${a.id} - ${a.org.name}`));
+        console.log(
+          `The account "${accountId}" was not found. Here were the accounts returned:`,
+        );
+        if (results?.accounts)
+          results.accounts.forEach((a) =>
+            console.log(`${a.id} - ${a.org.name}`),
+          );
         res.send({
           status: 'ok',
           data: {
             error_type: 'ACCOUNT_MISSING',
             error_code: 'ACCOUNT_MISSING',
             status: 'rejected',
-            reason:
-              `The account "${accountId}" was not found. Try unlinking and relinking the account.`,
+            reason: `The account "${accountId}" was not found. Try unlinking and relinking the account.`,
           },
         });
         return;

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -87,7 +87,22 @@ app.post(
     }
 
     try {
-      const account = results.accounts.find((a) => a.id === accountId);
+      const account = !results?.accounts || results.accounts.find((a) => a.id === 'f' + accountId);
+      if (!account) {
+        console.log(`The account "${accountId}" was not found. Here were the accounts returned:`);
+        if (results?.accounts) results.accounts.forEach((a) => console.log(`${a.id} - ${a.org.name}`));
+        res.send({
+          status: 'ok',
+          data: {
+            error_type: 'ACCOUNT_MISSING',
+            error_code: 'ACCOUNT_MISSING',
+            status: 'rejected',
+            reason:
+              `The account "${accountId}" was not found. Try unlinking and relinking the account.`,
+          },
+        });
+        return;
+      }
 
       const needsAttention = results.errors.find(
         (e) => e === `Connection to ${account.org.name} may need attention`,

--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -87,7 +87,7 @@ app.post(
     }
 
     try {
-      const account = !results?.accounts || results.accounts.find((a) => a.id === 'f' + accountId);
+      const account = !results?.accounts || results.accounts.find((a) => a.id === accountId);
       if (!account) {
         console.log(`The account "${accountId}" was not found. Here were the accounts returned:`);
         if (results?.accounts) results.accounts.forEach((a) => console.log(`${a.id} - ${a.org.name}`));

--- a/upcoming-release-notes/412.md
+++ b/upcoming-release-notes/412.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [psybers]
+---
+
+Show better error if SimpleFIN account cant be found.


### PR DESCRIPTION
As reported in https://discord.com/channels/937901803608096828/1270489947320881286.

It seems sometimes the account ID can't be found in the response from SimpleFIN.  Not sure why exactly, but the least we can do is give a better error and some console logs to help figure out what happened.