### PR TITLE
Fallback creditorName to remittanceInformationUnstructured in BANKINTER_BKBKESMM

### DIFF
--- a/src/app-gocardless/banks/bankinter-bkbkesmm.js
+++ b/src/app-gocardless/banks/bankinter-bkbkesmm.js
@@ -24,12 +24,15 @@ export default {
   },
 
   normalizeTransaction(transaction, _booked) {
-    transaction.debtorName = transaction.debtorName?.replaceAll(';', ' ');
-    transaction.creditorName = transaction.creditorName?.replaceAll(';', ' ');
     transaction.remittanceInformationUnstructured =
       transaction.remittanceInformationUnstructured
         .replaceAll(/\/Txt\/(\w\|)?/gi, '')
         .replaceAll(';', ' ');
+
+    transaction.debtorName = transaction.debtorName?.replaceAll(';', ' ');
+    transaction.creditorName =
+      transaction.creditorName?.replaceAll(';', ' ') ??
+      transaction.remittanceInformationUnstructured;
 
     return {
       ...transaction,

--- a/upcoming-release-notes/428.md
+++ b/upcoming-release-notes/428.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [hostyn]
+---
+
+Fallback creditorName to remittanceInformationUnstructured in BANKINTER_BKBKESMM


### PR DESCRIPTION
Before #353, `payeeName` would automatically fall back to `remittanceInformationUnstructured`. However, now it first falls back to `debtorName`, which I believe does not make much sense in this context.

Initially, I considered editing how the `payeeName` fallback works in `src/util/payee-name.js`. However, in the case of `BANKINTER_BKBKESMM`, when `creditorName` is not set, `remittanceInformationUnstructured` is actually the correct representation of the creditor's name. Therefore, I believe this fallback logic is appropriate for this scenario.