### PR TITLE
Prevent account fallback if name is defined in formatPayeeName

### DIFF
--- a/src/util/payee-name.js
+++ b/src/util/payee-name.js
@@ -20,6 +20,9 @@ export const formatPayeeName = (trans) => {
 
   // use the correct name field if it was found
   // if not, use whatever we can find
+
+  account = name ? account : trans.debtorAccount || trans.creditorAccount;
+
   name =
     name ||
     trans.debtorName ||
@@ -27,8 +30,6 @@ export const formatPayeeName = (trans) => {
     trans.remittanceInformationUnstructured ||
     (trans.remittanceInformationUnstructuredArray || []).join(', ') ||
     trans.additionalInformation;
-
-  account = account || trans.debtorAccount || trans.creditorAccount;
 
   if (name) {
     nameParts.push(title(name));

--- a/src/util/payee-name.js
+++ b/src/util/payee-name.js
@@ -21,6 +21,7 @@ export const formatPayeeName = (trans) => {
   // use the correct name field if it was found
   // if not, use whatever we can find
 
+  // if the primary name option is set, prevent the account from falling back
   account = name ? account : trans.debtorAccount || trans.creditorAccount;
 
   name =

--- a/upcoming-release-notes/429.md
+++ b/upcoming-release-notes/429.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [hostyn]
+---
+
+Prevent account fallback if name is defined in formatPayeeName


### PR DESCRIPTION
Note: This PR depends on #427 to work properly.

Currently, if `creditorAccount` is not set in a payment but `debtorAccount` is, `payeeName` ends up being `"creditorName (debtorAccount)"`, which doesn't make sense. The issue is reversed in income transactions.

This situation always occurs in `BANKINTER_BKBKESMM` payments, where `creditorAccount` is never provided, but `debtorAccount` is always set.

To address this, I have prevented the account from falling back if the primary name option is set.

Additionally, consider whether we should ever fallback the account. We might also want to avoid falling back the name to the opposite (e.g., payments shouldn’t fallback to `debtorName` if `creditorName` is not set, and income shouldn’t fallback to `creditorName` if `debtorName` is not set). Instead, fallback to `remittanceInformationUnstructured` should be considered first (see #428).