### PR TITLE
🧹 remove unused accountMetadata GoCardless API call on sync

### DIFF
--- a/src/app-gocardless/app-gocardless.js
+++ b/src/app-gocardless/app-gocardless.js
@@ -140,7 +140,6 @@ app.post(
 
     try {
       const {
-        iban,
         balances,
         institutionId,
         startingBalance,
@@ -155,7 +154,6 @@ app.post(
       res.send({
         status: 'ok',
         data: {
-          iban: iban ? await sha256String(iban) : null,
           balances,
           institutionId,
           startingBalance,

--- a/src/app-gocardless/services/gocardless-service.js
+++ b/src/app-gocardless/services/gocardless-service.js
@@ -185,7 +185,7 @@ export const goCardlessService = {
    * @throws {RateLimitError}
    * @throws {UnknownError}
    * @throws {ServiceError}
-   * @returns {Promise<{iban: string, balances: Array<import('../gocardless-node.types.js').Balance>, institutionId: string, transactions: {booked: Array<import('../gocardless-node.types.js').Transaction>, pending: Array<import('../gocardless-node.types.js').Transaction>, all: Array<import('../gocardless.types.js').TransactionWithBookedStatus>}, startingBalance: number}>}
+   * @returns {Promise<{balances: Array<import('../gocardless-node.types.js').Balance>, institutionId: string, transactions: {booked: Array<import('../gocardless-node.types.js').Transaction>, pending: Array<import('../gocardless-node.types.js').Transaction>, all: Array<import('../gocardless.types.js').TransactionWithBookedStatus>}, startingBalance: number}>}
    */
   getTransactionsWithBalance: async (
     requisitionId,
@@ -200,8 +200,7 @@ export const goCardlessService = {
       throw new AccountNotLinedToRequisition(accountId, requisitionId);
     }
 
-    const [accountMetadata, transactions, accountBalance] = await Promise.all([
-      goCardlessService.getAccountMetadata(accountId),
+    const [transactions, accountBalance] = await Promise.all([
       goCardlessService.getTransactions({
         institutionId: institution_id,
         accountId,
@@ -232,7 +231,6 @@ export const goCardlessService = {
     );
 
     return {
-      iban: accountMetadata.iban,
       balances: accountBalance.balances,
       institutionId: institution_id,
       startingBalance,

--- a/src/app-gocardless/services/tests/gocardless-service.spec.js
+++ b/src/app-gocardless/services/tests/gocardless-service.spec.js
@@ -168,7 +168,6 @@ describe('goCardlessService', () => {
         ),
       ).toEqual(
         expect.objectContaining({
-          iban: mockAccountMetaData.iban,
           balances: mockedBalances.balances,
           institutionId: mockRequisition.institution_id,
           startingBalance: expect.any(Number),

--- a/upcoming-release-notes/435.md
+++ b/upcoming-release-notes/435.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Optimise GoCardless sync to reduce API usage by removing accountMetadata call


### PR DESCRIPTION
Part of #431 

IBAN wasn't actually used anywhere in the client side after it was returned by the server, removing the accountMetadata call results in one API call fewer per sync.

For easy checking:
https://github.com/actualbudget/actual/blob/af5fd5b3efeef1628ad583b661fa0539d4d0f63e/packages/loot-core/src/server/accounts/sync.ts#L119-L123