### PR TITLE
🧹 optimise GoCardless bank sync to use fewer api calls

### DIFF
--- a/src/app-gocardless/app-gocardless.js
+++ b/src/app-gocardless/app-gocardless.js
@@ -142,8 +142,13 @@ app.post(
 app.post(
   '/transactions',
   handleError(async (req, res) => {
-    const { requisitionId, startDate, endDate, accountId, includeBalance } =
-      req.body;
+    const {
+      requisitionId,
+      startDate,
+      endDate,
+      accountId,
+      includeBalance = true,
+    } = req.body;
 
     try {
       if (includeBalance) {

--- a/src/app-gocardless/app-gocardless.js
+++ b/src/app-gocardless/app-gocardless.js
@@ -142,34 +142,59 @@ app.post(
 app.post(
   '/transactions',
   handleError(async (req, res) => {
-    const { requisitionId, startDate, endDate, accountId } = req.body;
+    const { requisitionId, startDate, endDate, accountId, includeBalance } =
+      req.body;
 
     try {
-      const {
-        balances,
-        institutionId,
-        startingBalance,
-        transactions: { booked, pending, all },
-      } = await goCardlessService.getTransactionsWithBalance(
-        requisitionId,
-        accountId,
-        startDate,
-        endDate,
-      );
-
-      res.send({
-        status: 'ok',
-        data: {
+      if (includeBalance) {
+        const {
           balances,
           institutionId,
           startingBalance,
-          transactions: {
-            booked,
-            pending,
-            all,
+          transactions: { booked, pending, all },
+        } = await goCardlessService.getTransactionsWithBalance(
+          requisitionId,
+          accountId,
+          startDate,
+          endDate,
+        );
+
+        res.send({
+          status: 'ok',
+          data: {
+            balances,
+            institutionId,
+            startingBalance,
+            transactions: {
+              booked,
+              pending,
+              all,
+            },
           },
-        },
-      });
+        });
+      } else {
+        const {
+          institutionId,
+          transactions: { booked, pending, all },
+        } = await goCardlessService.getNormalizedTransactions(
+          requisitionId,
+          accountId,
+          startDate,
+          endDate,
+        );
+
+        res.send({
+          status: 'ok',
+          data: {
+            institutionId,
+            transactions: {
+              booked,
+              pending,
+              all,
+            },
+          },
+        });
+      }
     } catch (error) {
       const sendErrorResponse = (data) =>
         res.send({ status: 'ok', data: { ...data, details: error.details } });

--- a/upcoming-release-notes/436.md
+++ b/upcoming-release-notes/436.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Optimise GoCardless sync to reduce API usage by removing balance information


### PR DESCRIPTION
Depends on merge of #435 

Part of #431 
Complimentary to PR in actual: actualbudget/actual#3279

The balance fetched from gocardless is used to calculate the starting balance, which is only relevant when a completely blank account is synced. This change lays the groundwork in the server to allow the client side to be more selective in what it retrieves.