### PR TITLE
Fix wrong payeeName used for KBC_KREDBEBB

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -2,6 +2,7 @@ import AbancaCaglesmm from './banks/abanca-caglesmm.js';
 import AmericanExpressAesudef1 from './banks/american-express-aesudef1.js';
 import BankinterBkbkesmm from './banks/bankinter-bkbkesmm.js';
 import Belfius from './banks/belfius_gkccbebb.js';
+import Berliner_Sparkasse_beladebexxx from './banks/berliner_sparkasse_beladebexxx.js';
 import BnpBeGebabebb from './banks/bnp-be-gebabebb.js';
 import DanskeBankDabNO22 from './banks/danskebank-dabno22.js';
 import EasybankBawaatww from './banks/easybank-bawaatww.js';
@@ -10,6 +11,7 @@ import IngIngbrobu from './banks/ing-ingbrobu.js';
 import IngIngddeff from './banks/ing-ingddeff.js';
 import IngPlIngbplpw from './banks/ing-pl-ingbplpw.js';
 import IntegrationBank from './banks/integration-bank.js';
+import KBCkredbebb from './banks/kbc_kredbebb.js';
 import MbankRetailBrexplpw from './banks/mbank-retail-brexplpw.js';
 import NationwideNaiaGB21 from './banks/nationwide-naiagb21.js';
 import NorwegianXxNorwnok1 from './banks/norwegian-xx-norwnok1.js';
@@ -17,17 +19,16 @@ import SEBKortBankAB from './banks/seb-kort-bank-ab.js';
 import SEBPrivat from './banks/seb-privat.js';
 import SandboxfinanceSfin0000 from './banks/sandboxfinance-sfin0000.js';
 import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
-import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
+import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
-import Berliner_Sparkasse_beladebexxx from './banks/berliner_sparkasse_beladebexxx.js';
-import KBCkredbebb from './banks/kbc_kredbebb.js';
 
 export const banks = [
   AbancaCaglesmm,
   AmericanExpressAesudef1,
   BankinterBkbkesmm,
   Belfius,
+  Berliner_Sparkasse_beladebexxx,
   BnpBeGebabebb,
   DanskeBankDabNO22,
   EasybankBawaatww,
@@ -35,6 +36,7 @@ export const banks = [
   IngIngbrobu,
   IngIngddeff,
   IngPlIngbplpw,
+  KBCkredbebb,
   MbankRetailBrexplpw,
   NationwideNaiaGB21,
   NorwegianXxNorwnok1,
@@ -42,11 +44,9 @@ export const banks = [
   SEBPrivat,
   SandboxfinanceSfin0000,
   SparNordSpNoDK22,
-  SpkMarburgBiedenkopfHeladef1mar,
   SpkKarlsruhekarsde66,
+  SpkMarburgBiedenkopfHeladef1mar,
   VirginNrnbgb22,
-  Berliner_Sparkasse_beladebexxx,
-  KBCkredbebb,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -21,6 +21,7 @@ import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-hela
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
 import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
 import Berliner_Sparkasse_beladebexxx from './banks/berliner_sparkasse_beladebexxx.js';
+import KBCkredbebb from './banks/kbc_kredbebb.js';
 
 export const banks = [
   AbancaCaglesmm,
@@ -45,6 +46,7 @@ export const banks = [
   SpkKarlsruhekarsde66,
   VirginNrnbgb22,
   Berliner_Sparkasse_beladebexxx,
+  KBCkredbebb,
 ];
 
 export default (institutionId) =>

--- a/src/app-gocardless/banks/kbc_kredbebb.js
+++ b/src/app-gocardless/banks/kbc_kredbebb.js
@@ -33,7 +33,9 @@ export default {
     if (Number(transaction.transactionAmount.amount) > 0) {
       return {
         ...transaction,
-        payeeName: transaction.debtorName,
+        payeeName:
+          transaction.debtorName ||
+          transaction.remittanceInformationUnstructured,
         date: transaction.bookingDate || transaction.valueDate,
       };
     }

--- a/src/app-gocardless/banks/kbc_kredbebb.js
+++ b/src/app-gocardless/banks/kbc_kredbebb.js
@@ -30,7 +30,7 @@ export default {
    * remittanceInformationUnstructured.
    */
   normalizeTransaction(transaction, _booked) {
-    if (transaction.transactionAmount.amount > 0) {
+    if (Number(transaction.transactionAmount.amount) > 0) {
       return {
         ...transaction,
         payeeName: transaction.debtorName,

--- a/src/app-gocardless/banks/kbc_kredbebb.js
+++ b/src/app-gocardless/banks/kbc_kredbebb.js
@@ -6,17 +6,17 @@ import Fallback from './integration-bank.js';
  * f.e. Proxy Poel BE Gent Betaling met Apple Pay via Maestro 23-08-2024 om 14.03 uur XXXX XXXX XXXX XXXX -> Proxy Poel BE Gent
  */
 function extractPayeeName(remittanceInformationUnstructured) {
-  const indexForRemoval =
-    remittanceInformationUnstructured.lastIndexOf(' Betaling met') ||
-    remittanceInformationUnstructured.lastIndexOf(' Domiciliëring') ||
-    remittanceInformationUnstructured.lastIndexOf(
-      ' Doorlopende betalingsopdracht',
-    );
+  const indices = [
+    remittanceInformationUnstructured.lastIndexOf(' Betaling met'),
+    remittanceInformationUnstructured.lastIndexOf(' Domiciliëring'),
+    remittanceInformationUnstructured.lastIndexOf(' Overschrijving'),
+  ];
 
-  return (
-    remittanceInformationUnstructured.substring(0, indexForRemoval) ||
-    remittanceInformationUnstructured
-  );
+  const indexForRemoval = Math.max(...indices);
+
+  return indexForRemoval > -1
+    ? remittanceInformationUnstructured.substring(0, indexForRemoval)
+    : remittanceInformationUnstructured;
 }
 
 /** @type {import('./bank.interface.js').IBank} */
@@ -40,9 +40,9 @@ export default {
 
     return {
       ...transaction,
-      payeeName: extractPayeeName(
-        transaction.remittanceInformationUnstructured,
-      ),
+      payeeName:
+        transaction.creditorName ||
+        extractPayeeName(transaction.remittanceInformationUnstructured),
       date: transaction.bookingDate || transaction.valueDate,
     };
   },

--- a/src/app-gocardless/banks/kbc_kredbebb.js
+++ b/src/app-gocardless/banks/kbc_kredbebb.js
@@ -1,0 +1,49 @@
+import Fallback from './integration-bank.js';
+
+/**
+ * The remittance information contains creditorName, payments method, dates, etc.
+ * This function makes sure to only extract the creditorName based on the different indicators like "Betaling met".
+ * f.e. Proxy Poel BE Gent Betaling met Apple Pay via Maestro 23-08-2024 om 14.03 uur XXXX XXXX XXXX XXXX -> Proxy Poel BE Gent
+ */
+function extractPayeeName(remittanceInformationUnstructured) {
+  const indexForRemoval =
+    remittanceInformationUnstructured.lastIndexOf(' Betaling met') ||
+    remittanceInformationUnstructured.lastIndexOf(' Domiciliëring') ||
+    remittanceInformationUnstructured.lastIndexOf(
+      ' Doorlopende betalingsopdracht',
+    );
+
+  return (
+    remittanceInformationUnstructured.substring(0, indexForRemoval) ||
+    remittanceInformationUnstructured
+  );
+}
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  ...Fallback,
+
+  institutionIds: ['KBC_KREDBEBB'],
+
+  /**
+   * For negative amounts, the only payee information we have is returned in
+   * remittanceInformationUnstructured.
+   */
+  normalizeTransaction(transaction, _booked) {
+    if (transaction.transactionAmount.amount > 0) {
+      return {
+        ...transaction,
+        payeeName: transaction.debtorName,
+        date: transaction.bookingDate || transaction.valueDate,
+      };
+    }
+
+    return {
+      ...transaction,
+      payeeName: extractPayeeName(
+        transaction.remittanceInformationUnstructured,
+      ),
+      date: transaction.bookingDate || transaction.valueDate,
+    };
+  },
+};

--- a/src/app-gocardless/banks/tests/kbc_kredbebb.spec.js
+++ b/src/app-gocardless/banks/tests/kbc_kredbebb.spec.js
@@ -1,0 +1,36 @@
+import KBCkredbebb from '../kbc_kredbebb.js';
+
+describe('kbc_kredbebb', () => {
+  describe('#normalizeTransaction', () => {
+    it('returns the remittanceInformationUnstructured as payeeName when the amount is negative', () => {
+      const transaction = {
+        remittanceInformationUnstructured:
+          'CARREFOUR ST GIL BE1060 BRUXELLES Betaling met Google Pay via Debit Mastercard 28-08-2024 om 19.15 uur 5127 04XX XXXX 1637 5853 98XX XXXX 2266 JOHN SMITH',
+        transactionAmount: { amount: '-10.99', currency: 'EUR' },
+      };
+      const normalizedTransaction = KBCkredbebb.normalizeTransaction(
+        transaction,
+        true,
+      );
+      expect(normalizedTransaction.payeeName).toEqual(
+        'CARREFOUR ST GIL BE1060 BRUXELLES',
+      );
+    });
+
+    it('returns the debtorName as payeeName when the amount is positive', () => {
+      const transaction = {
+        debtorName: 'CARREFOUR ST GIL BE1060 BRUXELLES',
+        remittanceInformationUnstructured:
+          'CARREFOUR ST GIL BE1060 BRUXELLES Betaling met Google Pay via Debit Mastercard 28-08-2024 om 19.15 uur 5127 04XX XXXX 1637 5853 98XX XXXX 2266 JOHN SMITH',
+        transactionAmount: { amount: '10.99', currency: 'EUR' },
+      };
+      const normalizedTransaction = KBCkredbebb.normalizeTransaction(
+        transaction,
+        true,
+      );
+      expect(normalizedTransaction.payeeName).toEqual(
+        'CARREFOUR ST GIL BE1060 BRUXELLES',
+      );
+    });
+  });
+});

--- a/upcoming-release-notes/442.md
+++ b/upcoming-release-notes/442.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ArnaudWeyts]
+---
+
+Fix wrong payeeName used for KBC_KREDBEBB


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/3303

Since we only have the `remittanceInformationUnstructured` available to us to extract the payee (for negative amounts), writing a dedicated integration for this seems reasonable.

~I couldn't really test this any further as I ran into GoCardless rate limits 🙈 But the basic implementation was working.~ Seems to work for my accounts now.