### PR TITLE
Fix BancSabadell payee name based on the transaction amount

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -1,5 +1,6 @@
 import AbancaCaglesmm from './banks/abanca-caglesmm.js';
 import AmericanExpressAesudef1 from './banks/american-express-aesudef1.js';
+import BancsabadellBsabesbb from './banks/bancsabadell-bsabesbbb.js';
 import BankinterBkbkesmm from './banks/bankinter-bkbkesmm.js';
 import Belfius from './banks/belfius_gkccbebb.js';
 import BnpBeGebabebb from './banks/bnp-be-gebabebb.js';
@@ -25,6 +26,7 @@ import Berliner_Sparkasse_beladebexxx from './banks/berliner_sparkasse_beladebex
 export const banks = [
   AbancaCaglesmm,
   AmericanExpressAesudef1,
+  BancsabadellBsabesbb,
   BankinterBkbkesmm,
   Belfius,
   BnpBeGebabebb,

--- a/src/app-gocardless/banks/bancsabadell-bsabesbbb.js
+++ b/src/app-gocardless/banks/bancsabadell-bsabesbbb.js
@@ -1,0 +1,36 @@
+import Fallback from './integration-bank.js';
+
+import { formatPayeeName } from '../../util/payee-name.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  ...Fallback,
+
+  institutionIds: ['BANCSABADELL_BSABESBB'],
+
+  accessValidForDays: 180,
+
+  // Sabadell transactions don't get the creditorName/debtorName properly
+  normalizeTransaction(transaction, _booked) {
+    const amount = transaction.transactionAmount.amount;
+
+    // The amount is negative for outgoing transactions, positive for incoming transactions.
+    const isCreditorPayee = Number.parseFloat(amount) < 0;
+
+    const payeeName = transaction.remittanceInformationUnstructuredArray
+      .join(' ')
+      .trim();
+
+    // The payee name is the creditor name for outgoing transactions and the debtor name for incoming transactions.
+    const creditorName = isCreditorPayee ? payeeName : null;
+    const debtorName = isCreditorPayee ? null : payeeName;
+
+    transaction.creditorName = creditorName;
+    transaction.debtorName = debtorName;
+
+    return {
+      ...transaction,
+      payeeName: formatPayeeName(transaction),
+    };
+  },
+};

--- a/src/app-gocardless/banks/tests/bancsabadell-bsabesbbb.spec.js
+++ b/src/app-gocardless/banks/tests/bancsabadell-bsabesbbb.spec.js
@@ -1,0 +1,39 @@
+import Sabadell from '../bancsabadell-bsabesbbb.js';
+
+describe('BancSabadell', () => {
+  describe('#normalizeTransaction', () => {
+    describe('returns the creditorName and debtorName from remittanceInformationUnstructuredArray', () => {
+      it('debtor role - amount < 0', () => {
+        const transaction = {
+          transactionAmount: { amount: '-100', currency: 'EUR' },
+          remittanceInformationUnstructuredArray: ['some-creditor-name'],
+          internalTransactionId: 'd7dca139cf31d9',
+          transactionId: '04704109322',
+        };
+        const normalizedTransaction = Sabadell.normalizeTransaction(
+          transaction,
+          true,
+        );
+        expect(normalizedTransaction.creditorName).toEqual(
+          'some-creditor-name',
+        );
+        expect(normalizedTransaction.debtorName).toEqual(null);
+      });
+
+      it('creditor role - amount > 0', () => {
+        const transaction = {
+          transactionAmount: { amount: '100', currency: 'EUR' },
+          remittanceInformationUnstructuredArray: ['some-debtor-name'],
+          internalTransactionId: 'd7dca139cf31d9',
+          transactionId: '04704109322',
+        };
+        const normalizedTransaction = Sabadell.normalizeTransaction(
+          transaction,
+          true,
+        );
+        expect(normalizedTransaction.debtorName).toEqual('some-debtor-name');
+        expect(normalizedTransaction.creditorName).toEqual(null);
+      });
+    });
+  });
+});

--- a/upcoming-release-notes/445.md
+++ b/upcoming-release-notes/445.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [davidmartos96]
+---
+
+Fix BancSabadell payee name based on the transaction amount


### PR DESCRIPTION
The goCardless API for this bank doesn't return creditor and debtor names with its appropriate role based on the transaction amount, which makes Actual infer an incorrect payee name. So we just use the remittance information directly.

Hopefully this is ok, first time contributing.
Great project!