### PR TITLE
Update link to "Writing Good Release Notes"

### DIFF
--- a/upcoming-release-notes/README.md
+++ b/upcoming-release-notes/README.md
@@ -1,1 +1,1 @@
-See the [Writing Good Release Notes](https://github.com/actualbudget/docs#writing-good-release-notes) section of the README for the documentation repo for more information on how to create a release notes file here.
+See the [Writing Good Release Notes](https://actualbudget.org/docs/contributing/#writing-good-release-notes) section of the documentation for more information on how to create a release notes file.


### PR DESCRIPTION
Updated the link to the "Writing Good Release Notes" section due to resource relocation.