### PR TITLE
[WIP] Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       # - ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB=20
       # - ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB=50
       # - ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB=20
-      # See all options and more details at https://actualbudget.github.io/docs/Installing/Configuration
+      # See all options and more details at https://actualbudget.org/docs/config/
       # !! If you are not using any of these options, remove the 'environment:' tag entirely.
     volumes:
       # Change './actual-data' below to the path to the folder you want Actual to store its data in on your server.


### PR DESCRIPTION
Fixed link.

---

Query: I don't see those options in the linked docs. Do they still exist?

* `ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB`
* `ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB`
* `ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB`