### PR TITLE
fix: Sabadell Bank regression, missing date field during normalization

### DIFF
--- a/src/app-gocardless/banks/bancsabadell-bsabesbbb.js
+++ b/src/app-gocardless/banks/bancsabadell-bsabesbbb.js
@@ -31,6 +31,7 @@ export default {
     return {
       ...transaction,
       payeeName: formatPayeeName(transaction),
+      date: transaction.bookingDate || transaction.valueDate,
     };
   },
 };

--- a/src/app-gocardless/banks/tests/bancsabadell-bsabesbbb.spec.js
+++ b/src/app-gocardless/banks/tests/bancsabadell-bsabesbbb.spec.js
@@ -9,6 +9,7 @@ describe('BancSabadell', () => {
           remittanceInformationUnstructuredArray: ['some-creditor-name'],
           internalTransactionId: 'd7dca139cf31d9',
           transactionId: '04704109322',
+          bookingDate: '2022-05-01',
         };
         const normalizedTransaction = Sabadell.normalizeTransaction(
           transaction,
@@ -26,6 +27,7 @@ describe('BancSabadell', () => {
           remittanceInformationUnstructuredArray: ['some-debtor-name'],
           internalTransactionId: 'd7dca139cf31d9',
           transactionId: '04704109322',
+          bookingDate: '2022-05-01',
         };
         const normalizedTransaction = Sabadell.normalizeTransaction(
           transaction,
@@ -34,6 +36,22 @@ describe('BancSabadell', () => {
         expect(normalizedTransaction.debtorName).toEqual('some-debtor-name');
         expect(normalizedTransaction.creditorName).toEqual(null);
       });
+    });
+
+    it('extract date', () => {
+      const transaction = {
+        transactionAmount: { amount: '-100', currency: 'EUR' },
+        remittanceInformationUnstructuredArray: ['some-creditor-name'],
+        internalTransactionId: 'd7dca139cf31d9',
+        transactionId: '04704109322',
+        bookingDate: '2024-10-02',
+        valueDate: '2024-10-05',
+      };
+      const normalizedTransaction = Sabadell.normalizeTransaction(
+        transaction,
+        true,
+      );
+      expect(normalizedTransaction.date).toEqual('2024-10-02');
     });
   });
 });

--- a/upcoming-release-notes/474.md
+++ b/upcoming-release-notes/474.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [davidmartos96]
+---
+
+Fixes Sabadell Bank regression, by including the date field during normalization


### PR DESCRIPTION
Fixes a regression from a PR of mine from some weeks ago #445. I forgot to include the `date` field in the normalized transaction, which fails when syncing.