### PR TITLE
Allowing data dir to be overridden

### DIFF
--- a/src/load-config.js
+++ b/src/load-config.js
@@ -91,7 +91,7 @@ if (process.env.NODE_ENV === 'test') {
   };
 } else {
   config = {
-    mode: 'development', // Huh? We're in development when we are not in test?
+    mode: 'development',
     ...defaultConfig,
     dataDir: defaultDataDir,
     serverFiles: path.join(defaultDataDir, 'server-files'),

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -11,6 +11,11 @@ debug(`project root: '${projectRoot}'`);
 export const sqlDir = path.join(projectRoot, 'src', 'sql');
 
 let defaultDataDir = fs.existsSync('/data') ? '/data' : projectRoot;
+
+if (process.env.ACTUAL_DATA_DIR) {
+  defaultDataDir = process.env.ACTUAL_DATA_DIR;
+}
+
 debug(`default data directory: '${defaultDataDir}'`);
 
 function parseJSON(path, allowMissing = false) {
@@ -86,7 +91,7 @@ if (process.env.NODE_ENV === 'test') {
   };
 } else {
   config = {
-    mode: 'development',
+    mode: 'development', // Huh? We're in development when we are not in test?
     ...defaultConfig,
     dataDir: defaultDataDir,
     serverFiles: path.join(defaultDataDir, 'server-files'),
@@ -135,7 +140,6 @@ const finalConfig = {
         }
       : config.upload,
 };
-
 debug(`using port ${finalConfig.port}`);
 debug(`using hostname ${finalConfig.hostname}`);
 debug(`using data directory ${finalConfig.dataDir}`);

--- a/upcoming-release-notes/480.md
+++ b/upcoming-release-notes/480.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Allow data directory to be overridden by env variable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

I need this for integration with electron. 

I need to tell actual-server where the data dir is so it knows where to place the .migrate file.