### PR TITLE
Update easybank-bawaatww.js to change accessValidForDays: 179 from 180

### DIFF
--- a/src/app-gocardless/banks/easybank-bawaatww.js
+++ b/src/app-gocardless/banks/easybank-bawaatww.js
@@ -10,7 +10,7 @@ export default {
 
   institutionIds: ['EASYBANK_BAWAATWW'],
 
-  accessValidForDays: 180,
+  accessValidForDays: 179,
 
   // If date is same, sort by transactionId
   sortTransactions: (transactions = []) =>

--- a/upcoming-release-notes/486.md
+++ b/upcoming-release-notes/486.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Change access_valid_for_days from "180" to "179" for institution "EASYBANK_BAWAATWW"

--- a/upcoming-release-notes/486.md
+++ b/upcoming-release-notes/486.md
@@ -1,6 +1,6 @@
 ---
 category: Enhancements
-authors: [psybers]
+authors: [clutwo]
 ---
 
 Change access_valid_for_days from "180" to "179" for institution "EASYBANK_BAWAATWW"


### PR DESCRIPTION
Fix linking accounts for easybank Austria:

![image](https://github.com/user-attachments/assets/61107c44-6eba-427a-8261-8122c23e7e82)

Fixes #446 