### PR TITLE
🐛  Fix migrations not working on fresh clone

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,10 @@
-import run from './src/app.js';
 import runMigrations from './src/migrations.js';
 
 runMigrations()
-  .then(run)
+  .then(() => {
+    //import the app here becasue initial migrations need to be run first - they are dependencies of the app.js
+    import('./src/app.js').then((app) => app.default()); // run the app
+  })
   .catch((err) => {
     console.log('Error starting app:', err);
     process.exit(1);

--- a/upcoming-release-notes/487.md
+++ b/upcoming-release-notes/487.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix migrations not running properly on inital setup


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->


[This PR](https://github.com/actualbudget/actual-server/pull/432)  introduced a dependency in the app to have the user-files and server-files folders available. 

That's fine, but we need to ensure those folders exist before importing the app. If we don't the files-service will fail.

Related support thread: https://discord.com/channels/937901803608096828/1299430821509206160