### PR TITLE
Add support for SWEDBANK_HABALV22 transaction date

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -26,6 +26,7 @@ import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
 import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import SpkWormsAlzeyRiedMalade51wor from './banks/spk-worms-alzey-ried-malade51wor.js';
+import SwedbankHabaLV22 from './banks/swedbank-habalv22.js';
 import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
 
 export const banks = [
@@ -56,6 +57,7 @@ export const banks = [
   SpkKarlsruhekarsde66,
   SpkMarburgBiedenkopfHeladef1mar,
   SpkWormsAlzeyRiedMalade51wor,
+  SwedbankHabaLV22,
   VirginNrnbgb22,
 ];
 

--- a/src/app-gocardless/banks/swedbank-habalv22.js
+++ b/src/app-gocardless/banks/swedbank-habalv22.js
@@ -1,0 +1,32 @@
+import d from 'date-fns';
+
+import Fallback from './integration-bank.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  ...Fallback,
+
+  institutionIds: ['SWEDBANK_HABALV22'],
+
+  accessValidForDays: 90,
+
+  /**
+   * The actual transaction date for card transactions is only available in the remittanceInformationUnstructured field when the transaction is booked.
+   */
+  normalizeTransaction(transaction, booked) {
+    const dateMatch = transaction.remittanceInformationUnstructured?.match(
+      /PIRKUMS [\d*]+ (\d{2}.\d{2}.\d{4})/,
+    );
+
+    if (dateMatch) {
+      const extractedDate = d.parse(dateMatch[1], 'dd.MM.yyyy', new Date());
+
+      return Fallback.normalizeTransaction(
+        { ...transaction, bookingDate: d.format(extractedDate, 'yyyy-MM-dd') },
+        booked,
+      );
+    }
+
+    return Fallback.normalizeTransaction(transaction, booked);
+  },
+};

--- a/src/app-gocardless/banks/tests/swedbank-habalv22.spec.js
+++ b/src/app-gocardless/banks/tests/swedbank-habalv22.spec.js
@@ -26,44 +26,18 @@ describe('#normalizeTransaction', () => {
     ).toEqual('2024-10-28');
   });
 
-  it('normalizes non-card transactions as usual', () => {
-    const nonCardTransaction1 = {
+  it.each([
+    ['regular text', 'Some info'],
+    ['partial card text', 'PIRKUMS xxx'],
+    ['null value', null],
+  ])('normalizes non-card transaction with %s', (_, remittanceInfo) => {
+    const transaction = {
       ...cardTransaction,
-      remittanceInformationUnstructured: 'Some info',
+      remittanceInformationUnstructured: remittanceInfo,
     };
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction1, true)
-        .bookingDate,
-    ).toEqual('2024-10-29');
+    const normalized = SwedbankHabaLV22.normalizeTransaction(transaction, true);
 
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction1, true).date,
-    ).toEqual('2024-10-29');
-
-    const nonCardTransaction2 = {
-      ...cardTransaction,
-      remittanceInformationUnstructured: 'PIRKUMS xxx',
-    };
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction2, true)
-        .bookingDate,
-    ).toEqual('2024-10-29');
-
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction2, true).date,
-    ).toEqual('2024-10-29');
-
-    const nonCardTransaction3 = {
-      ...cardTransaction,
-      remittanceInformationUnstructured: null,
-    };
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction3, true)
-        .bookingDate,
-    ).toEqual('2024-10-29');
-
-    expect(
-      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction3, true).date,
-    ).toEqual('2024-10-29');
+    expect(normalized.bookingDate).toEqual('2024-10-29');
+    expect(normalized.date).toEqual('2024-10-29');
   });
 });

--- a/src/app-gocardless/banks/tests/swedbank-habalv22.spec.js
+++ b/src/app-gocardless/banks/tests/swedbank-habalv22.spec.js
@@ -1,0 +1,69 @@
+import SwedbankHabaLV22 from '../swedbank-habalv22.js';
+
+describe('#normalizeTransaction', () => {
+  const cardTransaction = {
+    transactionId: '2024102900000000-1',
+    bookingDate: '2024-10-29',
+    valueDate: '2024-10-29',
+    transactionAmount: {
+      amount: '-22.99',
+      currency: 'EUR',
+    },
+    creditorName: 'SOME CREDITOR NAME',
+    remittanceInformationUnstructured:
+      'PIRKUMS 424242******4242 28.10.2024 22.99 EUR (111111) SOME CREDITOR NAME',
+    bankTransactionCode: 'PMNT-CCRD-POSD',
+    internalTransactionId: 'fa000f86afb2cc7678bcff0000000000',
+  };
+
+  it('extracts card transaction date', () => {
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(cardTransaction, true).bookingDate,
+    ).toEqual('2024-10-28');
+
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(cardTransaction, true).date,
+    ).toEqual('2024-10-28');
+  });
+
+  it('normalizes non-card transactions as usual', () => {
+    const nonCardTransaction1 = {
+      ...cardTransaction,
+      remittanceInformationUnstructured: 'Some info',
+    };
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction1, true)
+        .bookingDate,
+    ).toEqual('2024-10-29');
+
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction1, true).date,
+    ).toEqual('2024-10-29');
+
+    const nonCardTransaction2 = {
+      ...cardTransaction,
+      remittanceInformationUnstructured: 'PIRKUMS xxx',
+    };
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction2, true)
+        .bookingDate,
+    ).toEqual('2024-10-29');
+
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction2, true).date,
+    ).toEqual('2024-10-29');
+
+    const nonCardTransaction3 = {
+      ...cardTransaction,
+      remittanceInformationUnstructured: null,
+    };
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction3, true)
+        .bookingDate,
+    ).toEqual('2024-10-29');
+
+    expect(
+      SwedbankHabaLV22.normalizeTransaction(nonCardTransaction3, true).date,
+    ).toEqual('2024-10-29');
+  });
+});

--- a/upcoming-release-notes/490.md
+++ b/upcoming-release-notes/490.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [dmednis]
+---
+
+Add support for "SWEDBANK_HABALV22" transaction date


### PR DESCRIPTION
Extracts transaction date from `remittanceInformationUnstructured` for card transactions since it is not correct in the actual `bookedDate` and `valueDate` fields.