### PR TITLE
`ING_PL_INGBPLPW` should prefer valueDate over bookingDate

### DIFF
--- a/src/app-gocardless/banks/ing-pl-ingbplpw.js
+++ b/src/app-gocardless/banks/ing-pl-ingbplpw.js
@@ -27,7 +27,7 @@ export default {
     return {
       ...transaction,
       payeeName: formatPayeeName(transaction),
-      date: transaction.bookingDate || transaction.valueDate,
+      date: transaction.valueDate ?? transaction.bookingDate,
     };
   },
 

--- a/upcoming-release-notes/493.md
+++ b/upcoming-release-notes/493.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+GoCardless: `ING_PL_INGBPLPW` should prefer valueDate over bookingDate


### PR DESCRIPTION
Reported in Github, valueDate is more accurate for `ING_PL_INGBPLPW`