### PR TITLE
use SimpleFin pending flag

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -202,7 +202,7 @@ function getAccountResponse(results, accountId, startDate) {
 
     let dateToUse = 0;
 
-    if (trans.posted == 0) {
+    if (trans.pending ?? trans.posted == 0) {
       newTrans.booked = false;
       dateToUse = trans.transacted_at;
     } else {


### PR DESCRIPTION
Looking at the SimpleFin docs, `posted === 0` is not always a reliable indicator of transaction cleared status. We should prefer the pending flag if present.

![image](https://github.com/user-attachments/assets/cb44ef69-d15a-42a8-9c03-2cf68e536fcd)
