### PR TITLE
fix: Fix the auth proxy trust by ensuring the proxy is in the trust

### DIFF
--- a/src/account-db.js
+++ b/src/account-db.js
@@ -53,9 +53,12 @@ export function getLoginMethod(req) {
     return req.body.loginMethod;
   }
 
-  const activeMethod = getActiveLoginMethod();
+  if (config.loginMethod) {
+    return config.loginMethod;
+  }
 
-  return config.loginMethod || activeMethod || 'password';
+  const activeMethod = getActiveLoginMethod();
+  return activeMethod || 'password';
 }
 
 export async function bootstrap(loginSettings) {

--- a/src/account-db.js
+++ b/src/account-db.js
@@ -48,7 +48,8 @@ export function getActiveLoginMethod() {
 export function getLoginMethod(req) {
   if (
     typeof req !== 'undefined' &&
-    (req.body || { loginMethod: null }).loginMethod
+    (req.body || { loginMethod: null }).loginMethod &&
+    config.allowedLoginMethods.includes(req.body.loginMethod)
   ) {
     return req.body.loginMethod;
   }

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -14,7 +14,6 @@ import {
 } from './account-db.js';
 import { changePassword, loginWithPassword } from './accounts/password.js';
 import { isValidRedirectUrl, loginWithOpenIdSetup } from './accounts/openid.js';
-import config from './load-config.js';
 
 let app = express();
 app.use(express.json());
@@ -60,10 +59,6 @@ app.post('/login', async (req, res) => {
   let loginMethod = getLoginMethod(req);
   console.log('Logging in via ' + loginMethod);
   let tokenRes = null;
-  if (!config.allowedLoginMethods.includes(loginMethod)) {
-    res.send({ status: 'error', reason: 'login-method-unsupported' });
-    return;
-  }
   switch (loginMethod) {
     case 'header': {
       let headerVal = req.get('x-actual-password') || '';

--- a/src/app-account.js
+++ b/src/app-account.js
@@ -11,6 +11,7 @@ import {
   needsBootstrap,
   getLoginMethod,
 } from './account-db.js';
+import config from './load-config.js';
 
 let app = express();
 app.use(errorMiddleware);
@@ -45,6 +46,10 @@ app.post('/login', (req, res) => {
   let loginMethod = getLoginMethod(req);
   console.log('Logging in via ' + loginMethod);
   let tokenRes = null;
+  if (!config.allowedLoginMethods.includes(loginMethod)) {
+    res.send({ status: 'error', reason: 'login-method-unsupported' });
+    return;
+  }
   switch (loginMethod) {
     case 'header': {
       let headerVal = req.get('x-actual-password') || '';

--- a/src/app.js
+++ b/src/app.js
@@ -20,6 +20,7 @@ process.on('unhandledRejection', (reason) => {
 
 app.disable('x-powered-by');
 app.use(cors());
+app.set('trust proxy', config.trustedProxies);
 app.use(
   rateLimit({
     windowMs: 60 * 1000,

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -1,9 +1,13 @@
 import { ServerOptions } from 'https';
 
+type LoginMethod = 'password' | 'header';
+
 export interface Config {
   mode: 'test' | 'development';
-  loginMethod: 'password' | 'header';
+  loginMethod: LoginMethod;
+  allowedLoginMethods: LoginMethod[];
   trustedProxies: string[];
+  trustedAuthProxies?: string[];
   dataDir: string;
   projectRoot: string;
   port: number;

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -54,7 +54,8 @@ if (process.env.ACTUAL_CONFIG_PATH) {
 /** @type {Omit<import('./config-types.js').Config, 'mode' | 'dataDir' | 'serverFiles' | 'userFiles'>} */
 let defaultConfig = {
   loginMethod: 'password',
-  // assume local networks are trusted for header authentication
+  allowedLoginMethods: ['password', 'header'],
+  // assume local networks are trusted
   trustedProxies: [
     '10.0.0.0/8',
     '172.16.0.0/12',
@@ -62,6 +63,9 @@ let defaultConfig = {
     'fc00::/7',
     '::1/128',
   ],
+  // fallback to trustedProxies, but in the future trustedProxies will only be used for express trust
+  // and trustedAuthProxies will just be for header auth
+  trustedAuthProxies: null,
   port: 5006,
   hostname: '::',
   webRoot: path.join(
@@ -105,9 +109,21 @@ const finalConfig = {
   loginMethod: process.env.ACTUAL_LOGIN_METHOD
     ? process.env.ACTUAL_LOGIN_METHOD.toLowerCase()
     : config.loginMethod,
+  allowedLoginMethods: process.env.ACTUAL_ALLOWED_LOGIN_METHODS
+    ? process.env.ACTUAL_ALLOWED_LOGIN_METHODS.split(',')
+        .map((q) => q.trim().toLowerCase())
+        .filter(Boolean)
+    : config.allowedLoginMethods,
   trustedProxies: process.env.ACTUAL_TRUSTED_PROXIES
-    ? process.env.ACTUAL_TRUSTED_PROXIES.split(',').map((q) => q.trim())
+    ? process.env.ACTUAL_TRUSTED_PROXIES.split(',')
+        .map((q) => q.trim())
+        .filter(Boolean)
     : config.trustedProxies,
+  trustedAuthProxies: process.env.ACTUAL_TRUSTED_AUTH_PROXIES
+    ? process.env.ACTUAL_TRUSTED_AUTH_PROXIES.split(',')
+        .map((q) => q.trim())
+        .filter(Boolean)
+    : config.trustedAuthProxies,
   port: +process.env.ACTUAL_PORT || +process.env.PORT || config.port,
   hostname: process.env.ACTUAL_HOSTNAME || config.hostname,
   serverFiles: process.env.ACTUAL_SERVER_FILES || config.serverFiles,

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -224,6 +224,11 @@ debug(`using user files directory ${finalConfig.userFiles}`);
 debug(`using web root directory ${finalConfig.webRoot}`);
 debug(`using login method ${finalConfig.loginMethod}`);
 debug(`using trusted proxies ${finalConfig.trustedProxies.join(', ')}`);
+debug(
+  `using trusted auth proxies ${
+    finalConfig.trustedAuthProxies?.join(', ') ?? 'same as trusted proxies'
+  }`,
+);
 
 if (finalConfig.https) {
   debug(`using https key: ${'*'.repeat(finalConfig.https.key.length)}`);

--- a/src/load-config.js
+++ b/src/load-config.js
@@ -54,7 +54,7 @@ if (process.env.ACTUAL_CONFIG_PATH) {
 /** @type {Omit<import('./config-types.js').Config, 'mode' | 'dataDir' | 'serverFiles' | 'userFiles'>} */
 let defaultConfig = {
   loginMethod: 'password',
-  allowedLoginMethods: ['password', 'header'],
+  allowedLoginMethods: ['password', 'header', 'openid'],
   // assume local networks are trusted
   trustedProxies: [
     '10.0.0.0/8',

--- a/src/util/validate-user.js
+++ b/src/util/validate-user.js
@@ -1,6 +1,5 @@
 import { getSession } from '../account-db.js';
 import config from '../load-config.js';
-import proxyaddr from 'proxy-addr';
 import ipaddr from 'ipaddr.js';
 
 /**
@@ -30,24 +29,23 @@ export default function validateUser(req, res) {
 }
 
 export function validateAuthHeader(req) {
-  if (config.trustedProxies.length == 0) {
-    return true;
-  }
-
-  let sender = proxyaddr(req, 'uniquelocal');
-  let sender_ip = ipaddr.process(sender);
+  // fallback to trustedProxies when trustedAuthProxies not set
+  const trustedAuthProxies = config.trustedAuthProxies ?? config.trustedProxies;
+  // ensure the first hop from our server is trusted
+  let peer = req.socket.remoteAddress;
+  let peerIp = ipaddr.process(peer);
   const rangeList = {
-    allowed_ips: config.trustedProxies.map((q) => ipaddr.parseCIDR(q)),
+    allowed_ips: trustedAuthProxies.map((q) => ipaddr.parseCIDR(q)),
   };
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   // @ts-ignore : there is an error in the ts definition for the function, but this is valid
-  var matched = ipaddr.subnetMatch(sender_ip, rangeList, 'fail');
+  var matched = ipaddr.subnetMatch(peerIp, rangeList, 'fail');
   /* eslint-enable @typescript-eslint/ban-ts-comment */
   if (matched == 'allowed_ips') {
-    console.info(`Header Auth Login permitted from ${sender}`);
+    console.info(`Header Auth Login permitted from ${peer}`);
     return true;
   } else {
-    console.warn(`Header Auth Login attempted from ${sender}`);
+    console.warn(`Header Auth Login attempted from ${peer}`);
     return false;
   }
 }

--- a/upcoming-release-notes/499.md
+++ b/upcoming-release-notes/499.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix the auth proxy trust by ensuring the proxy is in the trust


### PR DESCRIPTION
- Validate that the closest peer to the express server is trusted proxy
- Add a new trustedAuthProxies config to eventually be used for this
- Add a allowedLoginMethod config to enable fully disabling header auth
- uses the old trustedProxies config to configure express trust (to resolve https://github.com/actualbudget/actual-server/issues/392 at the same time)


Doc update PR: https://github.com/actualbudget/docs/pull/581

Fixes: https://github.com/actualbudget/actual-server/issues/371
Fixes: https://github.com/actualbudget/actual-server/issues/392

