### PR TITLE
use built-in Docker init, remove tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY yarn.lock package.json .yarnrc.yml ./
 RUN yarn workspaces focus --all --production
 
 FROM node:18-bookworm-slim as prod
-RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=actual
 ARG USER_UID=1001
@@ -21,6 +20,5 @@ COPY --from=base /app/node_modules /app/node_modules
 COPY package.json app.js ./
 COPY src ./src
 COPY migrations ./migrations
-ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
 EXPOSE 5006
 CMD ["node", "app.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,5 @@ services:
       # '/data' is the path Actual will look for its files in by default, so leave that as-is.
       - ./actual-data:/data
     restart: unless-stopped
+    # forward signals to Node.js for faster container shutdown
+    init: true

--- a/docker/edge-alpine.Dockerfile
+++ b/docker/edge-alpine.Dockerfile
@@ -16,7 +16,7 @@ RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_
 RUN unzip /tmp/desktop-client.zip -d /public
 
 FROM alpine:3.18 as prod
-RUN apk add --no-cache nodejs tini
+RUN apk add --no-cache nodejs
 
 ARG USERNAME=actual
 ARG USER_UID=1001
@@ -31,7 +31,6 @@ COPY --from=base /public /public
 COPY package.json app.js ./
 COPY src ./src
 COPY migrations ./migrations
-ENTRYPOINT ["/sbin/tini","-g",  "--"]
 ENV ACTUAL_WEB_ROOT=/public
 EXPOSE 5006
 CMD ["node", "app.js"]

--- a/docker/edge-ubuntu.Dockerfile
+++ b/docker/edge-ubuntu.Dockerfile
@@ -15,7 +15,6 @@ RUN curl -L -o /tmp/desktop-client.zip --header "Authorization: Bearer ${GITHUB_
 RUN unzip /tmp/desktop-client.zip -d /public
 
 FROM node:18-bookworm-slim as prod
-RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=actual
 ARG USER_UID=1001
@@ -31,7 +30,6 @@ COPY --from=base /public /public
 COPY package.json app.js ./
 COPY src ./src
 COPY migrations ./migrations
-ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
 ENV ACTUAL_WEB_ROOT=/public
 EXPOSE 5006
 CMD ["node", "app.js"]

--- a/docker/stable-alpine.Dockerfile
+++ b/docker/stable-alpine.Dockerfile
@@ -8,7 +8,7 @@ RUN yarn workspaces focus --all --production
 RUN if [ "$(uname -m)" = "armv7l" ]; then npm install bcrypt better-sqlite3 --build-from-source; fi
 
 FROM alpine:3.18 as prod
-RUN apk add --no-cache nodejs tini
+RUN apk add --no-cache nodejs
 
 ARG USERNAME=actual
 ARG USER_UID=1001
@@ -22,6 +22,5 @@ COPY --from=base /app/node_modules /app/node_modules
 COPY package.json app.js ./
 COPY src ./src
 COPY migrations ./migrations
-ENTRYPOINT ["/sbin/tini","-g",  "--"]
 EXPOSE 5006
 CMD ["node", "app.js"]

--- a/docker/stable-ubuntu.Dockerfile
+++ b/docker/stable-ubuntu.Dockerfile
@@ -7,7 +7,6 @@ RUN if [ "$(uname -m)" = "armv7l" ]; then yarn config set taskPoolConcurrency 2;
 RUN yarn workspaces focus --all --production
 
 FROM node:18-bookworm-slim as prod
-RUN apt-get update && apt-get install tini && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG USERNAME=actual
 ARG USER_UID=1001
@@ -22,6 +21,5 @@ COPY --from=base /app/node_modules /app/node_modules
 COPY package.json app.js ./
 COPY src ./src
 COPY migrations ./migrations
-ENTRYPOINT ["/usr/bin/tini","-g",  "--"]
 EXPOSE 5006
 CMD ["node", "app.js"]


### PR DESCRIPTION
We no longer need tini with recent versions of Docker.

See:

* https://docs.docker.com/reference/cli/docker/container/run/#init
* https://github.com/krallin/tini?#using-tini

Tested and seems to work as expected when `--init` is included in `docker run` command line or `init: true` is included in the Docker Compose service stanza.

I **think** it's OK to exclude the `-g` argument (pass along signals to process group) since we only run the one node process, but I'm not certain.

Look for a correspoding change in the docs repo.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
