### PR TITLE
fix bug in batch SimpleFIN startDate logic

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -210,12 +210,13 @@ function getAccountResponse(results, accountId, startDate) {
       dateToUse = trans.posted;
     }
 
-    newTrans.bookingDate = getDate(new Date(dateToUse * 1000));
-    if (newTrans.bookingDate < startDate) {
+    const transactionDate = new Date(dateToUse * 1000);
+
+    if (transactionDate < startDate) {
       continue;
     }
 
-    newTrans.date = newTrans.bookingDate;
+    newTrans.date = getDate(transactionDate);
     newTrans.payeeName = trans.payee;
     newTrans.remittanceInformationUnstructured = trans.description;
     newTrans.transactionAmount = { amount: trans.amount, currency: 'USD' };

--- a/upcoming-release-notes/504.md
+++ b/upcoming-release-notes/504.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix bug in batch SimpleFIN startDate logic


### PR DESCRIPTION
The comparison here wasn't like for like and was always failing, resulting in the start date being ignored