### PR TITLE
Return GoCardless rate limit information on error

### DIFF
--- a/src/app-gocardless/app-gocardless.js
+++ b/src/app-gocardless/app-gocardless.js
@@ -201,8 +201,14 @@ app.post(
         });
       }
     } catch (error) {
+      const headers = error.details?.response?.headers ?? {};
+
+      const rateLimitHeaders = Object.fromEntries(
+        Object.entries(headers).filter(([key]) => key.startsWith('http_x_ratelimit'))
+      );
+
       const sendErrorResponse = (data) =>
-        res.send({ status: 'ok', data: { ...data, details: error.details } });
+        res.send({ status: 'ok', data: { ...data, details: error.details, rateLimitHeaders }});
 
       switch (true) {
         case error instanceof RequisitionNotLinked:

--- a/src/app-gocardless/app-gocardless.js
+++ b/src/app-gocardless/app-gocardless.js
@@ -204,11 +204,16 @@ app.post(
       const headers = error.details?.response?.headers ?? {};
 
       const rateLimitHeaders = Object.fromEntries(
-        Object.entries(headers).filter(([key]) => key.startsWith('http_x_ratelimit'))
+        Object.entries(headers).filter(([key]) =>
+          key.startsWith('http_x_ratelimit'),
+        ),
       );
 
       const sendErrorResponse = (data) =>
-        res.send({ status: 'ok', data: { ...data, details: error.details, rateLimitHeaders }});
+        res.send({
+          status: 'ok',
+          data: { ...data, details: error.details, rateLimitHeaders },
+        });
 
       switch (true) {
         case error instanceof RequisitionNotLinked:

--- a/upcoming-release-notes/509.md
+++ b/upcoming-release-notes/509.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Add more logging for GoCardless rate limit information


### PR DESCRIPTION
Unfortunately we can only get this information from the error object from the nordigen-node package. This just adds a little more info to the error sent to the client.

Complimentary PR: https://github.com/actualbudget/actual/pull/3895