### PR TITLE
Add proper transaction formatting for Stadtsparkasse Düsseldorf (Germany)

### DIFF
--- a/src/app-gocardless/bank-factory.js
+++ b/src/app-gocardless/bank-factory.js
@@ -31,6 +31,7 @@ import SparNordSpNoDK22 from './banks/sparnord-spnodk22.js';
 import SpkKarlsruhekarsde66 from './banks/spk-karlsruhe-karsde66.js';
 import SpkMarburgBiedenkopfHeladef1mar from './banks/spk-marburg-biedenkopf-heladef1mar.js';
 import SpkWormsAlzeyRiedMalade51wor from './banks/spk-worms-alzey-ried-malade51wor.js';
+import SskDusseldorfDussdeddxxx from './banks/ssk-dusseldorf-dussdeddxxx.js';
 import SwedbankHabaLV22 from './banks/swedbank-habalv22.js';
 import VirginNrnbgb22 from './banks/virgin_nrnbgb22.js';
 
@@ -67,6 +68,7 @@ export const banks = [
   SpkKarlsruhekarsde66,
   SpkMarburgBiedenkopfHeladef1mar,
   SpkWormsAlzeyRiedMalade51wor,
+  SskDusseldorfDussdeddxxx,
   SwedbankHabaLV22,
   VirginNrnbgb22,
 ];

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -30,7 +30,7 @@ export default {
       transaction.remittanceInformationUnstructured ??
       transaction.remittanceInformationStructured ??
       transaction.remittanceInformationStructuredArray?.join(' ');
-    
+
     if (transaction.additionalInformation)
       remittanceInformationUnstructured +=
         ' ' + transaction.additionalInformation;
@@ -39,11 +39,11 @@ export default {
       transaction.ultimateCreditor ||
       transaction.creditorName ||
       transaction.debtorName;
-    
+
     transaction.creditorName = usefulCreditorName;
     transaction.remittanceInformationUnstructured =
       remittanceInformationUnstructured;
-    
+
     return {
       ...transaction,
       payeeName: formatPayeeName(transaction),

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -1,39 +1,22 @@
 import Fallback from './integration-bank.js';
 
-import { formatPayeeName } from '../../util/payee-name.js';
-
 /** @type {import('./bank.interface.js').IBank} */
 export default {
   ...Fallback,
 
   institutionIds: ['SSK_DUSSELDORF_DUSSDEDDXXX'],
 
-  accessValidForDays: 90,
-
-  /**
-   * Following the GoCardless documentation[0] we should prefer `bookingDate`
-   * here, though some of their bank integrations uses the date field
-   * differently from what's described in their documentation and so it's
-   * sometimes necessary to use `valueDate` instead.
-   *
-   *   [0]: https://nordigen.zendesk.com/hc/en-gb/articles/7899367372829-valueDate-and-bookingDate-for-transactions
-   */
   normalizeTransaction(transaction, _booked) {
-    const date = transaction.bookingDate || transaction.valueDate;
-    if (!date) {
-      return null;
-    }
 
-    let remittanceInformationUnstructured;
-
-    remittanceInformationUnstructured =
+    let remittanceInformationUnstructured =
       transaction.remittanceInformationUnstructured ??
       transaction.remittanceInformationStructured ??
       transaction.remittanceInformationStructuredArray?.join(' ');
 
     if (transaction.additionalInformation)
-      remittanceInformationUnstructured +=
-        ' ' + transaction.additionalInformation;
+      remittanceInformationUnstructured = (remittanceInformationUnstructured ?? '') 
+      + ' ' 
+      + transaction.additionalInformation;
 
     const usefulCreditorName =
       transaction.ultimateCreditor ||
@@ -44,10 +27,6 @@ export default {
     transaction.remittanceInformationUnstructured =
       remittanceInformationUnstructured;
 
-    return {
-      ...transaction,
-      payeeName: formatPayeeName(transaction),
-      date: transaction.bookingDate || transaction.valueDate,
-    };
+    return Fallback.normalizeTransaction(transaction, _booked);
   },
 };

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -1,0 +1,53 @@
+import Fallback from './integration-bank.js';
+
+import { formatPayeeName } from '../../util/payee-name.js';
+
+/** @type {import('./bank.interface.js').IBank} */
+export default {
+  ...Fallback,
+
+  institutionIds: ['SSK_DUSSELDORF_DUSSDEDDXXX'],
+
+  accessValidForDays: 90,
+
+  /**
+   * Following the GoCardless documentation[0] we should prefer `bookingDate`
+   * here, though some of their bank integrations uses the date field
+   * differently from what's described in their documentation and so it's
+   * sometimes necessary to use `valueDate` instead.
+   *
+   *   [0]: https://nordigen.zendesk.com/hc/en-gb/articles/7899367372829-valueDate-and-bookingDate-for-transactions
+   */
+  normalizeTransaction(transaction, _booked) {
+    const date = transaction.bookingDate || transaction.valueDate;
+    if (!date) {
+      return null;
+    }
+
+    let remittanceInformationUnstructured;
+
+    remittanceInformationUnstructured =
+      transaction.remittanceInformationUnstructured ??
+      transaction.remittanceInformationStructured ??
+      transaction.remittanceInformationStructuredArray?.join(' ');
+    
+    if (transaction.additionalInformation)
+      remittanceInformationUnstructured +=
+        ' ' + transaction.additionalInformation;
+
+    const usefulCreditorName =
+      transaction.ultimateCreditor ||
+      transaction.creditorName ||
+      transaction.debtorName;
+    
+    transaction.creditorName = usefulCreditorName;
+    transaction.remittanceInformationUnstructured =
+      remittanceInformationUnstructured;
+    
+    return {
+      ...transaction,
+      payeeName: formatPayeeName(transaction),
+      date: transaction.bookingDate || transaction.valueDate,
+    };
+  },
+};

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -15,9 +15,9 @@ export default {
 
     if (transaction.additionalInformation)
       remittanceInformationUnstructured = 
-        (remittanceInformationUnstructured ?? '')
-        + ' ' 
-        + transaction.additionalInformation;
+        (remittanceInformationUnstructured ?? '') +
+        ' ' +
+        transaction.additionalInformation;
 
     const usefulCreditorName =
       transaction.ultimateCreditor ||

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -7,16 +7,17 @@ export default {
   institutionIds: ['SSK_DUSSELDORF_DUSSDEDDXXX'],
 
   normalizeTransaction(transaction, _booked) {
-
+    // Prioritize unstructured information, falling back to structured formats
     let remittanceInformationUnstructured =
       transaction.remittanceInformationUnstructured ??
       transaction.remittanceInformationStructured ??
       transaction.remittanceInformationStructuredArray?.join(' ');
 
     if (transaction.additionalInformation)
-      remittanceInformationUnstructured = (remittanceInformationUnstructured ?? '') 
-      + ' ' 
-      + transaction.additionalInformation;
+      remittanceInformationUnstructured = 
+        (remittanceInformationUnstructured ?? '')
+        + ' ' 
+        + transaction.additionalInformation;
 
     const usefulCreditorName =
       transaction.ultimateCreditor ||

--- a/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk-dusseldorf-dussdeddxxx.js
@@ -14,7 +14,7 @@ export default {
       transaction.remittanceInformationStructuredArray?.join(' ');
 
     if (transaction.additionalInformation)
-      remittanceInformationUnstructured = 
+      remittanceInformationUnstructured =
         (remittanceInformationUnstructured ?? '') +
         ' ' +
         transaction.additionalInformation;

--- a/upcoming-release-notes/531.md
+++ b/upcoming-release-notes/531.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [DennaGherlyn]
+---
+
+Add gocardless formatter for Stadtsparkasse Düsseldorf (Germany)

--- a/upcoming-release-notes/531.md
+++ b/upcoming-release-notes/531.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [DennaGherlyn]
 ---
 
-Add gocardless formatter for Stadtsparkasse Düsseldorf (Germany)
+Add GoCardless formatter for `SSK_DUSSELDORF_DUSSDEDDXXX` Stadtsparkasse Düsseldorf (Germany) 


### PR DESCRIPTION
This adds a gocardless formatter for the bank Stadtsparkasse Düsseldorf (Germany).
Mainly it fixes the creditor name for cases where payments are managed by a third-party provider by using the `ultimateCreditor` in addition to the other possible fields and fills the notes property.