### PR TITLE
Improve abn amro sync

### DIFF
--- a/src/app-gocardless/banks/abnamro_abnanl2a.js
+++ b/src/app-gocardless/banks/abnamro_abnanl2a.js
@@ -37,13 +37,6 @@ export default {
     transaction.debtorName = transaction.debtorName || payeeName;
     transaction.creditorName = transaction.creditorName || payeeName;
 
-    // There are anumber of superfluous keywords in the remittanceInformation.
-    // Remove them to aboid clutter in notes.
-    const keywordsToRemove = ['.EA, Betaalpas', ',PAS\\d{3}', 'NR:.+, '];
-    const regex = new RegExp(keywordsToRemove.join('|'), 'g');
-    transaction.remittanceInformationUnstructured =
-      remittanceInformationUnstructured.replace(regex, '').trim();
-
     return {
       ...transaction,
       payeeName: formatPayeeName(transaction),

--- a/src/app-gocardless/banks/abnamro_abnanl2a.js
+++ b/src/app-gocardless/banks/abnamro_abnanl2a.js
@@ -24,16 +24,14 @@ export default {
 
   normalizeTransaction(transaction, _booked) {
     // There is no remittanceInformationUnstructured, so we'll make it
-    let remittanceInformationUnstructured =
+    transaction.remittanceInformationUnstructured =
       transaction.remittanceInformationUnstructuredArray.join(', ');
 
     // Remove clutter to extract the payee from remittanceInformationUnstructured ...
     // ... when not otherwise provided.
-    const matches =
-      remittanceInformationUnstructured.match(/(?:Betaalpas|Google Pay)(.+),PAS/);
-    const payeeName = matches
-      ? matches[1].replace(/.+\*/, '').trim()
-      : undefined;
+    const payeeName = transaction.remittanceInformationUnstructuredArray
+      .map((el) => el.match(/^(?:.*\*)?(.+),PAS\d+$/))
+      .find((match) => match)?.[1];
     transaction.debtorName = transaction.debtorName || payeeName;
     transaction.creditorName = transaction.creditorName || payeeName;
 

--- a/src/app-gocardless/banks/abnamro_abnanl2a.js
+++ b/src/app-gocardless/banks/abnamro_abnanl2a.js
@@ -25,12 +25,12 @@ export default {
   normalizeTransaction(transaction, _booked) {
     // There is no remittanceInformationUnstructured, so we'll make it
     let remittanceInformationUnstructured =
-      transaction.remittanceInformationUnstructuredArray.join(' ');
+      transaction.remittanceInformationUnstructuredArray.join(', ');
 
     // Remove clutter to extract the payee from remittanceInformationUnstructured ...
     // ... when not otherwise provided.
     const matches =
-      remittanceInformationUnstructured.match(/Betaalpas(.+),PAS/);
+      remittanceInformationUnstructured.match(/(?:Betaalpas|Google Pay)(.+),PAS/);
     const payeeName = matches
       ? matches[1].replace(/.+\*/, '').trim()
       : undefined;

--- a/src/app-gocardless/banks/tests/abnamro_abnanl2a.spec.js
+++ b/src/app-gocardless/banks/tests/abnamro_abnanl2a.spec.js
@@ -25,9 +25,37 @@ describe('AbnamroAbnanl2a', () => {
       );
 
       expect(normalizedTransaction.remittanceInformationUnstructured).toEqual(
-        'My Payee Name 09.12.23/15:43 CITY',
+        'BEA, Betaalpas, My Payee Name,PAS123, NR:123A4B, 09.12.23/15:43, CITY',
       );
       expect(normalizedTransaction.payeeName).toEqual('My Payee Name');
+    });
+
+    it('correctly extracts the payee for google pay', () => {
+      const transaction = {
+        transactionId: '0123456789012345',
+        bookingDate: '2023-12-11',
+        valueDateTime: '2023-12-09T15:43:37.950',
+        transactionAmount: {
+          amount: '-10.00',
+          currency: 'EUR',
+        },
+        remittanceInformationUnstructuredArray: [
+          'BEA, Google Pay',
+          'CCV*Other payee name,PAS123',
+          'NR:123A4B, 09.12.23/15:43',
+          'CITY',
+        ],
+      };
+
+      const normalizedTransaction = AbnamroAbnanl2a.normalizeTransaction(
+        transaction,
+        false,
+      );
+
+      expect(normalizedTransaction.remittanceInformationUnstructured).toEqual(
+        'BEA, Google Pay, CCV*Other payee name,PAS123, NR:123A4B, 09.12.23/15:43, CITY',
+      );
+      expect(normalizedTransaction.payeeName).toEqual('Other Payee Name');
     });
   });
 });

--- a/upcoming-release-notes/534.md
+++ b/upcoming-release-notes/534.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [UnderKoen]
+---
+
+Make Google Pay transactions work for ABNAMRO_ABNANL2A


### PR DESCRIPTION
For payment made with google pay this also cleanes the payee_name.

Removes the removal of certain terms in the notes. As for me it really helpful to have BEA and GEA in the notes. (GEA is for atm withdraws) 

The cleaning should be achieved with https://github.com/actualbudget/actual/issues/3606 I think. @nsulzer would you be opposed by this?