### PR TITLE
Corner case transaction for GoCardLess adapater (ING Romania)

### DIFF
--- a/src/app-gocardless/banks/ing-ingbrobu.js
+++ b/src/app-gocardless/banks/ing-ingbrobu.js
@@ -16,7 +16,7 @@ export default {
     //For deduplication to work better, payeeName needs to be standardized
     //and converted from a pending transaction form ("payeeName":"Card no: xxxxxxxxxxxx1111"') to a booked transaction form ("payeeName":"Card no: Xxxx Xxxx Xxxx 1111")
     if (transaction.transactionId === 'NOTPROVIDED') {
-      //Some corner case transactions have a special field called `proprietaryBankTransactionCode`, this need to be copied to `remittanceInformationUnstructured`
+      //Some corner case transactions have the  `proprietaryBankTransactionCode` field, this need to be copied to `remittanceInformationUnstructured`
       if (
         transaction.proprietaryBankTransactionCode &&
         !transaction.remittanceInformationUnstructured

--- a/src/app-gocardless/banks/ing-ingbrobu.js
+++ b/src/app-gocardless/banks/ing-ingbrobu.js
@@ -18,7 +18,14 @@ export default {
     if (transaction.transactionId === 'NOTPROVIDED') {
       if (booked) {
         transaction.transactionId = transaction.internalTransactionId;
+
+        //Some corner case transactions have a special field called `proprietaryBankTransactionCode`, this need to be copied to `remittanceInformationUnstructured`
+        if (transaction.proprietaryBankTransactionCode) {
+          transaction.remittanceInformationUnstructured =
+            transaction.proprietaryBankTransactionCode;
+        }
         if (
+          transaction.remittanceInformationUnstructured &&
           transaction.remittanceInformationUnstructured
             .toLowerCase()
             .includes('card no:')
@@ -32,7 +39,12 @@ export default {
         }
       } else {
         transaction.transactionId = null;
+        if (transaction.proprietaryBankTransactionCode) {
+          transaction.remittanceInformationUnstructured =
+            transaction.proprietaryBankTransactionCode;
+        }
         if (
+          transaction.remittanceInformationUnstructured &&
           transaction.remittanceInformationUnstructured
             .toLowerCase()
             .includes('card no:')

--- a/src/app-gocardless/banks/ing-ingbrobu.js
+++ b/src/app-gocardless/banks/ing-ingbrobu.js
@@ -20,7 +20,10 @@ export default {
         transaction.transactionId = transaction.internalTransactionId;
 
         //Some corner case transactions have a special field called `proprietaryBankTransactionCode`, this need to be copied to `remittanceInformationUnstructured`
-        if (transaction.proprietaryBankTransactionCode) {
+        if (
+          transaction.proprietaryBankTransactionCode &&
+          !transaction.remittanceInformationUnstructured
+        ) {
           transaction.remittanceInformationUnstructured =
             transaction.proprietaryBankTransactionCode;
         }
@@ -39,7 +42,11 @@ export default {
         }
       } else {
         transaction.transactionId = null;
-        if (transaction.proprietaryBankTransactionCode) {
+
+        if (
+          transaction.proprietaryBankTransactionCode &&
+          !transaction.remittanceInformationUnstructured
+        ) {
           transaction.remittanceInformationUnstructured =
             transaction.proprietaryBankTransactionCode;
         }

--- a/src/app-gocardless/banks/ing-ingbrobu.js
+++ b/src/app-gocardless/banks/ing-ingbrobu.js
@@ -16,17 +16,17 @@ export default {
     //For deduplication to work better, payeeName needs to be standardized
     //and converted from a pending transaction form ("payeeName":"Card no: xxxxxxxxxxxx1111"') to a booked transaction form ("payeeName":"Card no: Xxxx Xxxx Xxxx 1111")
     if (transaction.transactionId === 'NOTPROVIDED') {
+      //Some corner case transactions have a special field called `proprietaryBankTransactionCode`, this need to be copied to `remittanceInformationUnstructured`
+      if (
+        transaction.proprietaryBankTransactionCode &&
+        !transaction.remittanceInformationUnstructured
+      ) {
+        transaction.remittanceInformationUnstructured =
+          transaction.proprietaryBankTransactionCode;
+      }
+
       if (booked) {
         transaction.transactionId = transaction.internalTransactionId;
-
-        //Some corner case transactions have a special field called `proprietaryBankTransactionCode`, this need to be copied to `remittanceInformationUnstructured`
-        if (
-          transaction.proprietaryBankTransactionCode &&
-          !transaction.remittanceInformationUnstructured
-        ) {
-          transaction.remittanceInformationUnstructured =
-            transaction.proprietaryBankTransactionCode;
-        }
         if (
           transaction.remittanceInformationUnstructured &&
           transaction.remittanceInformationUnstructured
@@ -43,13 +43,6 @@ export default {
       } else {
         transaction.transactionId = null;
 
-        if (
-          transaction.proprietaryBankTransactionCode &&
-          !transaction.remittanceInformationUnstructured
-        ) {
-          transaction.remittanceInformationUnstructured =
-            transaction.proprietaryBankTransactionCode;
-        }
         if (
           transaction.remittanceInformationUnstructured &&
           transaction.remittanceInformationUnstructured

--- a/src/app-gocardless/banks/ing-ingbrobu.js
+++ b/src/app-gocardless/banks/ing-ingbrobu.js
@@ -16,7 +16,7 @@ export default {
     //For deduplication to work better, payeeName needs to be standardized
     //and converted from a pending transaction form ("payeeName":"Card no: xxxxxxxxxxxx1111"') to a booked transaction form ("payeeName":"Card no: Xxxx Xxxx Xxxx 1111")
     if (transaction.transactionId === 'NOTPROVIDED') {
-      //Some corner case transactions have the  `proprietaryBankTransactionCode` field, this need to be copied to `remittanceInformationUnstructured`
+      //Some corner case transactions only have the `proprietaryBankTransactionCode` field, this need to be copied to `remittanceInformationUnstructured`
       if (
         transaction.proprietaryBankTransactionCode &&
         !transaction.remittanceInformationUnstructured

--- a/upcoming-release-notes/535.md
+++ b/upcoming-release-notes/535.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [spideraxal]
+---
+
+Add corner case transaction for ING Bank Romania


### PR DESCRIPTION
Hello,

I am updating my adapter for ING Romania. It seems there is a special transaction type (insurance provided by the bank itself for example), which does not have the `remittanceInformationUnstructured` field, only the `proprietaryBankTransactionCode` one.

This led to a `Cannot read properties of undefined (reading 'toLowerCase')` error, so no new transactions were synced. This commit fixes the issue.

<img width="806" alt="image" src="https://github.com/user-attachments/assets/214b38dd-ec50-48b7-9dca-08b94557fb1a" />