### PR TITLE
SSK_DUSSELDORF_DUSSDEDDXXX: remove non-booked transactions from import

### DIFF
--- a/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
@@ -12,6 +12,10 @@ export default {
     // to make the payee and notes field be of any use. It's filled with
     // a placeholder text and wouldn't be corrected on the next sync.
     if (!_booked) {
+      console.debug(
+        'Skipping unbooked transaction:',
+        transaction.transactionId,
+      );
       return null;
     }
 
@@ -22,10 +26,12 @@ export default {
       transaction.remittanceInformationStructuredArray?.join(' ');
 
     if (transaction.additionalInformation)
-      remittanceInformationUnstructured =
-        (remittanceInformationUnstructured ?? '') +
-        ' ' +
-        transaction.additionalInformation;
+      remittanceInformationUnstructured = [
+        remittanceInformationUnstructured,
+        transaction.additionalInformation,
+      ]
+        .filter(Boolean)
+        .join(' ');
 
     const usefulCreditorName =
       transaction.ultimateCreditor ||

--- a/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
@@ -7,6 +7,14 @@ export default {
   institutionIds: ['SSK_DUSSELDORF_DUSSDEDDXXX'],
 
   normalizeTransaction(transaction, _booked) {
+    // If the transaction is not booked yet by the bank, don't import it.
+    // Reason being that the transaction doesn't have the information yet
+    // to make the payee and notes field be of any use. It's filled with 
+    // a placeholder text and wouldn't be corrected on the next sync.
+    if (!_booked) {
+      return null;
+    }
+
     // Prioritize unstructured information, falling back to structured formats
     let remittanceInformationUnstructured =
       transaction.remittanceInformationUnstructured ??

--- a/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
+++ b/src/app-gocardless/banks/ssk_dusseldorf_dussdeddxxx.js
@@ -9,7 +9,7 @@ export default {
   normalizeTransaction(transaction, _booked) {
     // If the transaction is not booked yet by the bank, don't import it.
     // Reason being that the transaction doesn't have the information yet
-    // to make the payee and notes field be of any use. It's filled with 
+    // to make the payee and notes field be of any use. It's filled with
     // a placeholder text and wouldn't be corrected on the next sync.
     if (!_booked) {
       return null;

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -1,86 +1,97 @@
 import { jest } from '@jest/globals';
 import SskDusseldorfDussdeddxxx from '../ssk_dusseldorf_dussdeddxxx.js';
 
-beforeEach(() => {
-  jest.spyOn(console, 'debug').mockImplementation(() => {});
-});
+describe('ssk_dusseldorf_dussdeddxxx', () => {
+  let consoleSpy;
 
-afterEach(() => {
-  jest.restoreAllMocks();
-});
-
-describe('#normalizeTransaction', () => {
-  const bookedTransactionOne = {
-    transactionId: '2024102900000000-1',
-    bookingDate: '2024-10-29',
-    valueDate: '2024-10-29',
-    transactionAmount: {
-      amount: '-99.99',
-      currency: 'EUR',
-    },
-    creditorName: 'a useful creditor name',
-    remittanceInformationStructured: 'structured information',
-    remittanceInformationUnstructured: 'unstructured information',
-    additionalInformation: 'some additional information',
-  };
-
-  const bookedTransactionTwo = {
-    transactionId: '2024102900000000-2',
-    bookingDate: '2024-10-29',
-    valueDate: '2024-10-29',
-    transactionAmount: {
-      amount: '-99.99',
-      currency: 'EUR',
-    },
-    creditorName: 'a useful creditor name',
-    ultimateCreditor: 'ultimate creditor',
-    remittanceInformationStructured: 'structured information',
-    additionalInformation: 'some additional information',
-  };
-
-  it('properly combines remittance information', () => {
-    expect(
-      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
-        .remittanceInformationUnstructured,
-    ).toEqual('unstructured information some additional information');
-
-    expect(
-      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
-        .remittanceInformationUnstructured,
-    ).toEqual('structured information some additional information');
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'debug');
   });
 
-  it('prioritizes creditor names correctly', () => {
-    expect(
-      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
-        .payeeName,
-    ).toEqual('A Useful Creditor Name');
+  describe('#normalizeTransaction', () => {
+    const bookedTransactionOne = {
+      transactionId: '2024102900000000-1',
+      bookingDate: '2024-10-29',
+      valueDate: '2024-10-29',
+      transactionAmount: {
+        amount: '-99.99',
+        currency: 'EUR',
+      },
+      creditorName: 'a useful creditor name',
+      remittanceInformationStructured: 'structured information',
+      remittanceInformationUnstructured: 'unstructured information',
+      additionalInformation: 'some additional information',
+    };
 
-    expect(
-      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
-        .payeeName,
-    ).toEqual('Ultimate Creditor');
-  });
+    const bookedTransactionTwo = {
+      transactionId: '2024102900000000-2',
+      bookingDate: '2024-10-29',
+      valueDate: '2024-10-29',
+      transactionAmount: {
+        amount: '-99.99',
+        currency: 'EUR',
+      },
+      creditorName: 'a useful creditor name',
+      ultimateCreditor: 'ultimate creditor',
+      remittanceInformationStructured: 'structured information',
+      additionalInformation: 'some additional information',
+    };
 
-  const unbookedTransaction = {
-    transactionId: '2024102900000000-1',
-    valueDate: '2024-10-29',
-    transactionAmount: {
-      amount: '-99.99',
-      currency: 'EUR',
-    },
-    creditorName: 'some nonsensical creditor',
-    remittanceInformationUnstructured: 'some nonsensical information',
-  };
+    it('properly combines remittance information', () => {
+      expect(
+        SskDusseldorfDussdeddxxx.normalizeTransaction(
+          bookedTransactionOne,
+          true,
+        ).remittanceInformationUnstructured,
+      ).toEqual('unstructured information some additional information');
 
-  it('returns null for unbooked transactions', () => {
-    expect(
-      SskDusseldorfDussdeddxxx.normalizeTransaction(unbookedTransaction, false),
-    ).toBeNull();
+      expect(
+        SskDusseldorfDussdeddxxx.normalizeTransaction(
+          bookedTransactionTwo,
+          true,
+        ).remittanceInformationUnstructured,
+      ).toEqual('structured information some additional information');
+    });
 
-    expect(console.debug).toHaveBeenCalledWith(
-      'Skipping unbooked transaction:',
-      unbookedTransaction.transactionId,
-    );
+    it('prioritizes creditor names correctly', () => {
+      expect(
+        SskDusseldorfDussdeddxxx.normalizeTransaction(
+          bookedTransactionOne,
+          true,
+        ).payeeName,
+      ).toEqual('A Useful Creditor Name');
+
+      expect(
+        SskDusseldorfDussdeddxxx.normalizeTransaction(
+          bookedTransactionTwo,
+          true,
+        ).payeeName,
+      ).toEqual('Ultimate Creditor');
+    });
+
+    const unbookedTransaction = {
+      transactionId: '2024102900000000-1',
+      valueDate: '2024-10-29',
+      transactionAmount: {
+        amount: '-99.99',
+        currency: 'EUR',
+      },
+      creditorName: 'some nonsensical creditor',
+      remittanceInformationUnstructured: 'some nonsensical information',
+    };
+
+    it('returns null for unbooked transactions', () => {
+      expect(
+        SskDusseldorfDussdeddxxx.normalizeTransaction(
+          unbookedTransaction,
+          false,
+        ),
+      ).toBeNull();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Skipping unbooked transaction:',
+        unbookedTransaction.transactionId,
+      );
+    });
   });
 });

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -1,0 +1,72 @@
+import SskDusseldorfDussdeddxxx from '../ssk_dusseldorf_dussdeddxxx.js';
+
+describe('#normalizeTransaction', () => {
+  const bookedTransactionOne = {
+    transactionId: '2024102900000000-1',
+    bookingDate: '2024-10-29',
+    valueDate: '2024-10-29',
+    transactionAmount: {
+      amount: '-99.99',
+      currency: 'EUR',
+    },
+    creditorName: 'a useful creditor name',
+    remittanceInformationStructured: 'structured information',
+    remittanceInformationUnstructured: 'unstructured information',
+    additionalInformation: 'some aditional information',
+  };
+
+  const bookedTransactionTwo = {
+    transactionId: '2024102900000000-2',
+    bookingDate: '2024-10-29',
+    valueDate: '2024-10-29',
+    transactionAmount: {
+      amount: '-99.99',
+      currency: 'EUR',
+    },
+    creditorName: 'a useful creditor name',
+    ultimateCreditor: 'ultimate creditor',
+    remittanceInformationStructured: 'structured information',
+    additionalInformation: 'some aditional information',
+  };
+
+  it('properly combines remittance information', () => {
+    expect(
+      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
+        .remittanceInformationUnstructured,
+    ).toEqual('unstructured information some aditional information');
+
+    expect(
+      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
+        .remittanceInformationUnstructured,
+    ).toEqual('structured information some aditional information');
+  });
+
+  it('prioritizes creditor names correctly', () => {
+    expect(
+      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
+        .payeeName,
+    ).toEqual('a useful creditor name');
+
+    expect(
+      SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
+        .payeeName,
+    ).toEqual('ultimate creditor');
+  });
+
+  const unbookedTransaction = {
+    transactionId: '2024102900000000-1',
+    valueDate: '2024-10-29',
+    transactionAmount: {
+      amount: '-99.99',
+      currency: 'EUR',
+    },
+    creditorName: 'some nonsensical creditor',
+    remittanceInformationUnstructured: 'some nonsensical information',
+  };
+
+  it('returns null for unbooked transactions', () => {
+    expect(
+      SskDusseldorfDussdeddxxx.normalizeTransaction(unbookedTransaction, false),
+    ).toBeNull;
+  });
+});

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -45,12 +45,12 @@ describe('#normalizeTransaction', () => {
     expect(
       SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
         .payeeName,
-    ).toEqual('a useful creditor name');
+    ).toEqual('A Useful Creditor Name');
 
     expect(
       SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
         .payeeName,
-    ).toEqual('ultimate creditor');
+    ).toEqual('Ultimate Creditor');
   });
 
   const unbookedTransaction = {

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -1,5 +1,13 @@
 import SskDusseldorfDussdeddxxx from '../ssk_dusseldorf_dussdeddxxx.js';
 
+beforeEach(() => {
+  jest.spyOn(console, 'debug').mockImplementation();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('#normalizeTransaction', () => {
   const bookedTransactionOne = {
     transactionId: '2024102900000000-1',
@@ -12,7 +20,7 @@ describe('#normalizeTransaction', () => {
     creditorName: 'a useful creditor name',
     remittanceInformationStructured: 'structured information',
     remittanceInformationUnstructured: 'unstructured information',
-    additionalInformation: 'some aditional information',
+    additionalInformation: 'some additional information',
   };
 
   const bookedTransactionTwo = {
@@ -26,19 +34,19 @@ describe('#normalizeTransaction', () => {
     creditorName: 'a useful creditor name',
     ultimateCreditor: 'ultimate creditor',
     remittanceInformationStructured: 'structured information',
-    additionalInformation: 'some aditional information',
+    additionalInformation: 'some additional information',
   };
 
   it('properly combines remittance information', () => {
     expect(
       SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionOne, true)
         .remittanceInformationUnstructured,
-    ).toEqual('unstructured information some aditional information');
+    ).toEqual('unstructured information some additional information');
 
     expect(
       SskDusseldorfDussdeddxxx.normalizeTransaction(bookedTransactionTwo, true)
         .remittanceInformationUnstructured,
-    ).toEqual('structured information some aditional information');
+    ).toEqual('structured information some additional information');
   });
 
   it('prioritizes creditor names correctly', () => {
@@ -67,6 +75,11 @@ describe('#normalizeTransaction', () => {
   it('returns null for unbooked transactions', () => {
     expect(
       SskDusseldorfDussdeddxxx.normalizeTransaction(unbookedTransaction, false),
-    ).toBeNull;
+    ).toBeNull();
+
+    expect(console.debug).toHaveBeenCalledWith(
+      'Skipping unbooked transaction:',
+      unbookedTransaction.transactionId,
+    );
   });
 });

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -1,7 +1,8 @@
+import { jest } from '@jest/globals';
 import SskDusseldorfDussdeddxxx from '../ssk_dusseldorf_dussdeddxxx.js';
 
 beforeEach(() => {
-  jest.spyOn(console, 'debug').mockImplementation();
+  jest.spyOn(console, 'debug').mockImplementation(() => {});
 });
 
 afterEach(() => {

--- a/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
+++ b/src/app-gocardless/banks/tests/ssk_dusseldorf_dussdeddxxx.spec.js
@@ -8,6 +8,10 @@ describe('ssk_dusseldorf_dussdeddxxx', () => {
     consoleSpy = jest.spyOn(console, 'debug');
   });
 
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
   describe('#normalizeTransaction', () => {
     const bookedTransactionOne = {
       transactionId: '2024102900000000-1',

--- a/upcoming-release-notes/553.md
+++ b/upcoming-release-notes/553.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [DennaGherlyn]
+---
+
+Remove non-booked transactions from import of SSK_DUSSELDORF_DUSSDEDDXXX due to placeholder text in the payee and notes field


### PR DESCRIPTION
The "Stadtsparkasse Düsseldorf" fills uncleared transactions with placeholder text. This text is not useful for human eyes or rule mapping. When the transaction is cleared the bank replaces the text with the correct payee and updates the notes. These don't get picked up on the next import, because the fields are already filled, therefore I removed the import of uncleared transactions.