### PR TITLE
Sort SimpleFIN transactions in date order

### DIFF
--- a/src/app-simplefin/app-simplefin.js
+++ b/src/app-simplefin/app-simplefin.js
@@ -216,6 +216,7 @@ function getAccountResponse(results, accountId, startDate) {
       continue;
     }
 
+    newTrans.sortOrder = dateToUse;
     newTrans.date = getDate(transactionDate);
     newTrans.payeeName = trans.payee;
     newTrans.remittanceInformationUnstructured = trans.description;
@@ -231,7 +232,19 @@ function getAccountResponse(results, accountId, startDate) {
     all.push(newTrans);
   }
 
-  return { balances, startingBalance, transactions: { all, booked, pending } };
+  const bookedSorted = booked.sort((a, b) => b.sortOrder - a.sortOrder);
+  const pendingSorted = pending.sort((a, b) => b.sortOrder - a.sortOrder);
+  const allSorted = all.sort((a, b) => b.sortOrder - a.sortOrder);
+
+  return {
+    balances,
+    startingBalance,
+    transactions: {
+      all: allSorted,
+      booked: bookedSorted,
+      pending: pendingSorted,
+    },
+  };
 }
 
 function invalidToken(res) {

--- a/upcoming-release-notes/559.md
+++ b/upcoming-release-notes/559.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Ensure SimpleFIN transactions are sorted by date


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual-server/issues/556

Ensures that the client inserts the starting balance transaction in the right place.

To test, set up the test SimpleFIN credentials on an edge server and sync from blank - the starting balance transaction will be at the top. Try again on this build, it'll be in the correct pace at the bottom